### PR TITLE
Updating bind salt-formula to include support to manage Bind on Debian

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -8,10 +8,91 @@ bind_config:
     - managed
     - name: {{ map.config }}
     - source: {{ salt['pillar.get']('bind:config:tmpl', 'salt://bind/files/named.conf') }}
-    - user: {{ salt['pillar.get']('bind:config:user', 'root') }}
-    - group: {{ salt['pillar.get']('bind:config:group', 'named') }}
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', map.user ) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
     - mode: {{ salt['pillar.get']('bind:config:mode', '640') }}
     - require:
       - pkg: bind
     - watch_in:
       - service: bind
+
+named_directory:
+  file.directory:
+    - name: {{ map.named_directory }}
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: 775
+    - makedirs: True
+    - require:
+      - pkg: bind
+
+{% if grains['os_family'] == 'RedHat' %}
+bind_local_config:
+  file:
+    - managed
+    - name: {{ map.local_config }}
+    - source: 'salt://bind/files/redhat/named.conf.local'
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - require:
+      - pkg: bind
+{% endif %}
+
+{% if grains['os'] == 'Debian' %}
+bind_local_config:
+  file:
+    - managed
+    - name: {{ map.local_config }}
+    - source: 'salt://bind/files/debian/named.conf.local'
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - require:
+      - pkg: bind
+
+bind_options_config:
+  file:
+    - managed
+    - name: {{ map.options_config }}
+    - source: 'salt://bind/files/debian/named.conf.options'
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - require:
+      - pkg: bind
+
+bind_default_zones:
+  file:
+    - managed
+    - name: {{ map.default_zones_config }}
+    - source: 'salt://bind/files/debian/named.conf.default-zones'
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', 'root') }}
+    - group: {{ salt['pillar.get']('bind:config:group', 'bind') }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - require:
+      - pkg: bind
+{% endif %}
+
+{% for key,args in salt['pillar.get']('bind:configured_zones', {}).iteritems()  -%}
+{%- set file = salt['pillar.get']("available_zones:" + key + ":file") %}
+{% if args['type'] == "master" -%}
+zones-{{ file }}:
+  file:
+    - managed
+    - name: {{ map.named_directory }}/{{ file }}
+    - source: 'salt://bind/zones/{{ file }}'
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - watch_in:
+      - service: bind
+    - require:
+      - file: {{ map.named_directory }}
+{% endif %}
+{% endfor %}

--- a/bind/files/debian/named.conf
+++ b/bind/files/debian/named.conf
@@ -1,0 +1,11 @@
+// This is the primary configuration file for the BIND DNS server named.
+//
+// Please read /usr/share/doc/bind9/README.Debian.gz for information on the 
+// structure of BIND configuration files in Debian, *BEFORE* you customize 
+// this configuration file.
+//
+// If you are just adding zones, please do that in /etc/bind/named.conf.local
+
+include "/etc/bind/named.conf.options";
+include "/etc/bind/named.conf.local";
+include "/etc/bind/named.conf.default-zones";

--- a/bind/files/debian/named.conf.default-zones
+++ b/bind/files/debian/named.conf.default-zones
@@ -1,0 +1,28 @@
+// prime the server with knowledge of the root servers
+zone "." {
+      type hint;
+      file "/etc/bind/db.root";
+};
+
+// be authoritative for the localhost forward and reverse zones, and for
+// broadcast zones as per RFC 1912
+
+zone "localhost" {
+      type master;
+      file "/etc/bind/db.local";
+};
+
+zone "127.in-addr.arpa" {
+      type master;
+      file "/etc/bind/db.127";
+};
+
+zone "0.in-addr.arpa" {
+      type master;
+      file "/etc/bind/db.0";
+};
+
+zone "255.in-addr.arpa" {
+      type master;
+      file "/etc/bind/db.255";
+};

--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -1,0 +1,30 @@
+//
+// Do any local configuration here
+//
+
+// Consider adding the 1918 zones here, if they are not used in your
+// organization
+//include "/etc/bind/zones.rfc1918";
+
+{% for key,args in salt['pillar.get']('bind:configured_zones', {}).iteritems()  -%}
+{%- set file = salt['pillar.get']("available_zones:" + key + ":file") %}
+{%- set masters = salt['pillar.get']("available_zones:" + key + ":masters") %}
+zone "{{ key }}" {
+  type {{ args['type'] }};
+  file "zones/{{ file }}";
+  {% if args['type'] == "master" -%}
+    {% if args['notify'] -%}
+  notify yes;
+    {% else -%}
+  notify no;
+    {%- endif -%}
+  {% else -%}
+  masters { {{ masters }} };
+  {%- endif %}
+};
+{% endfor %}
+
+logging {
+  channel "querylog" { file "/var/log/bind9/query.log"; print-time yes; };
+  category queries { querylog; };
+};

--- a/bind/files/debian/named.conf.options
+++ b/bind/files/debian/named.conf.options
@@ -1,0 +1,19 @@
+options {
+        directory "/var/cache/bind";
+
+        // If there is a firewall between you and nameservers you want
+        // to talk to, you may need to fix the firewall to allow multiple
+        // ports to talk.  See http://www.kb.cert.org/vuls/id/800113
+
+        // If your ISP provided one or more IP addresses for stable
+        // nameservers, you probably want to use them as forwarders.
+        // Uncomment the following block, and insert the addresses replacing
+        // the all-0's placeholder.
+
+        // forwarders {
+        //      0.0.0.0;
+        // };
+
+        auth-nxdomain no;    # conform to RFC1035
+        //listen-on-v6 { any; };
+};

--- a/bind/files/named.conf
+++ b/bind/files/named.conf
@@ -1,64 +1,15 @@
-// 
-// /etc/named.conf
-//
+{% if ipv6 %}
+listen-on-v6 { {{ ipv6_listen }}; };
+{% endif %}
 
-options {
-	directory "/var/named";
-	pid-file "/run/named/named.pid";
-	auth-nxdomain yes;
-	datasize default;
-// Uncomment these to enable IPv6 connections support
-// IPv4 will still work:
-//	listen-on-v6 { any; };
-// Add this for no IPv4:
-//	listen-on { none; };
-
-	// Default security settings.
-	allow-recursion { 127.0.0.1; };
-	allow-transfer { none; };
-	allow-update { none; };
-    version none;
-    hostname none;
-    server-id none;
+{#
+{% for dns_zone in pillar['dns_zones'] %}
+zone "{{ dns_zone['zone'] }}" {
+        type {{ dns_zone['type'] }};
+        file "{{ dns_zone['file'] }}";
+        {% if dns_zone['type'] == "slave" %}
+        masters { {{ dns_zone['masters'] }} };
+        {% endif %}
 };
-
-zone "localhost" IN {
-	type master;
-	file "localhost.zone";
-	allow-transfer { any; };
-};
-
-zone "0.0.127.in-addr.arpa" IN {
-	type master;
-	file "127.0.0.zone";
-	allow-transfer { any; };
-};
-
-zone "." IN {
-	type hint;
-	file "root.hint";
-};
-
-//zone "example.org" IN {
-//	type slave;
-//	file "example.zone";
-//	masters {
-//		192.168.1.100; 
-//	};
-//	allow-query { any; };
-//	allow-transfer { any; };
-//};
-
-logging {
-        channel xfer-log {
-                file "/var/log/named.log";
-                print-category yes;
-                print-severity yes;
-                print-time yes;
-                severity info;
-        };
-        category xfer-in { xfer-log; };
-        category xfer-out { xfer-log; };
-        category notify { xfer-log; };
-};
-
+{% endfor %}
+#}

--- a/bind/files/redhat/named.conf
+++ b/bind/files/redhat/named.conf
@@ -1,0 +1,45 @@
+//
+// named.conf
+//
+// Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
+// server as a caching only nameserver (as a localhost DNS resolver only).
+//
+// See /usr/share/doc/bind*/sample/ for example named configuration files.
+//
+
+options {
+        //listen-on port 53 { 127.0.0.1; };
+        listen-on port 53 { any; };
+        listen-on-v6 port 53 { ::1; };
+        directory       "/var/named";
+        dump-file       "/var/named/data/cache_dump.db";
+        statistics-file "/var/named/data/named_stats.txt";
+        memstatistics-file "/var/named/data/named_mem_stats.txt";
+        allow-query     { any; };
+        recursion yes;
+
+        dnssec-enable yes;
+        dnssec-validation yes;
+        dnssec-lookaside auto;
+
+        /* Path to ISC DLV key */
+        bindkeys-file "/etc/named.iscdlv.key";
+
+        managed-keys-directory "/var/named/dynamic";
+};
+
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+
+zone "." IN {
+        type hint;
+        file "named.ca";
+};
+
+include "/etc/named.rfc1912.zones";
+include "/etc/named.conf.local";
+include "/etc/named.root.key";

--- a/bind/files/redhat/named.conf.local
+++ b/bind/files/redhat/named.conf.local
@@ -1,0 +1,21 @@
+//
+// Do any local configuration here
+//
+
+{% for key,args in salt['pillar.get']('bind:configured_zones', {}).iteritems()  -%}
+{%- set file = salt['pillar.get']("available_zones:" + key + ":file") %}
+{%- set masters = salt['pillar.get']("available_zones:" + key + ":masters") %}
+  zone "{{ key }}" {
+    type {{ args['type'] }};
+    file "data/{{ file }}";
+    {% if args['type'] == "master" -%}
+      {% if args['notify'] -%}
+    notify yes;
+      {% else -%}
+    notify no;
+      {%- endif %}
+    {% else -%}
+    masters { {{ masters }} };
+    {%- endif %}
+  };
+{% endfor %}

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -1,14 +1,22 @@
 {% set map = salt['grains.filter_by']({
     'Debian': {
         'pkgs': ['bind9', 'bind9utils'],
-        'service': 'named',
-
-        'config': '/etc/named.conf',
+        'service': 'bind9',
+        'config': '/etc/bind/named.conf',
+        'local_config': '/etc/bind/named.conf.local',
+        'options_config': '/etc/bind/named.conf.options',
+        'default_zones_config': '/etc/bind/named.conf.default_zones',
+        'named_directory': '/var/cache/bind/zones',
+        'user': 'root',
+        'group': 'bind',
     },
     'RedHat': {
         'pkgs': ['bind'],
         'service': 'named',
-
         'config': '/etc/named.conf',
+        'local_config': '/etc/named.conf.local',
+        'named_directory': '/var/named/data',
+        'user': 'root',
+        'group': 'named',
     },
 }, merge=salt['pillar.get']('bind:lookup')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -7,7 +7,21 @@ bind:
 
 bind:
   config:
-    tmpl: salt://bind/files/named.conf
+    tmpl: salt://bind/files/debian/named.conf
     user: root
     group: named
     mode: 640
+
+bind:
+  configured_zones:
+    sub.domain.com:
+      type: master
+      notify: False
+    1.168.192.in-addr.arpa:
+      type: master
+      notify: False
+
+available_zones:
+  sub.domain.org:
+    file: db.sub.domain.org
+    masters: "192.168.0.1;"


### PR DESCRIPTION
Updating bind salt-formula to include support to manage Bind on Debian based systems.  
Also including the ability to manage what zones are configured on DNS servers. 
Changing defaults to be pulled from the map.jinja.  
Added values to map.jinja for group and user.
