### PR TITLE
change grains to os_family instead of os (typeo?)

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -39,6 +39,8 @@ bind_local_config:
     - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
     - require:
       - pkg: bind
+    - watch_in:
+      - service: bind
 {% endif %}
 
 {% if grains['os_family'] == 'Debian' %}
@@ -53,6 +55,8 @@ bind_local_config:
     - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
     - require:
       - pkg: bind
+    - watch_in:
+      - service: bind
 
 bind_options_config:
   file:
@@ -65,6 +69,8 @@ bind_options_config:
     - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
     - require:
       - pkg: bind
+    - watch_in:
+      - service: bind
 
 bind_default_zones:
   file:
@@ -77,6 +83,8 @@ bind_default_zones:
     - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
     - require:
       - pkg: bind
+    - watch_in:
+      - service: bind
 {% endif %}
 
 {% for key,args in salt['pillar.get']('bind:configured_zones', {}).iteritems()  -%}


### PR DESCRIPTION
also added a restart on the service for all bind config files
