### PR TITLE
detect logrotate version and pass correct option

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -127,6 +127,7 @@ bind_default_zones:
   file:
     - managed
     - source: salt://bind/files/debian/logrotate_bind
+    - template: jinja
     - user: root
     - group: root
 

--- a/bind/files/debian/logrotate_bind
+++ b/bind/files/debian/logrotate_bind
@@ -7,5 +7,7 @@
     copytruncate
     compress
     create 0664 bind root
+    {% if not salt['pkg.version']('logrotate').startswith('3.7')-%}
     su
+    {% endif %}
 }


### PR DESCRIPTION
added an extra check in the log rotate file to see if the available version supports the 'su' directive 
