### PR TITLE
Switch logging dir to /var/log/named for Debian

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -81,6 +81,8 @@ bind_local_config:
     - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
     - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
     - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - context:
+        map: {{ map }}
     - require:
       - pkg: bind
     - watch_in:
@@ -114,7 +116,7 @@ bind_default_zones:
     - watch_in:
       - service: bind
 
-/var/log/bind9:
+{{ map.log_dir }}:
   file:
     - directory
     - user: root
@@ -123,12 +125,15 @@ bind_default_zones:
     - template: jinja
 
 
-/etc/logrotate.d/bind9:
+/etc/logrotate.d/{{ map.service }}:
   file:
     - managed
     - source: salt://bind/files/debian/logrotate_bind
     - user: root
     - group: root
+    - template: jinja
+    - context:
+        map: {{ map }}
 
 {% endif %}
 

--- a/bind/files/debian/logrotate_bind
+++ b/bind/files/debian/logrotate_bind
@@ -1,4 +1,4 @@
-/var/log/bind9/query.log {
+{{ map.log_dir }}/query.log {
     rotate 7
     daily
     missingok

--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -30,6 +30,6 @@ zone "{{ key }}" {
 {% endfor %}
 
 logging {
-  channel "querylog" { file "/var/log/bind9/query.log"; print-time yes; };
+  channel "querylog" { file "{{ map.log_dir }}/query.log"; print-time yes; };
   category queries { querylog; };
 };

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -8,6 +8,7 @@
         'options_config': '/etc/bind/named.conf.options',
         'default_zones_config': '/etc/bind/named.conf.default-zones',
         'named_directory': '/var/cache/bind/zones',
+        'log_dir': '/var/log/bind9',
         'user': 'root',
         'group': 'bind'
     },
@@ -17,7 +18,12 @@
         'config': '/etc/named.conf',
         'local_config': '/etc/named.conf.local',
         'named_directory': '/var/named/data',
+        'log_dir': '/var/log/named',
         'user': 'root',
         'group': 'named'
     },
-}, merge=salt['pillar.get']('bind:lookup')) %}
+}, merge=salt['grains.filter_by']({
+    'Ubuntu': {
+        'log_dir': '/var/log/named'
+    },
+}, grain='os', merge=salt['pillar.get']('bind:lookup'))) %}


### PR DESCRIPTION
Apparmor expects /var/log/named to be the logging directory for bind9
in Ubuntu 12.04 (and most likely 14.04).

This should address the problem in #16, but as I am not an expert in Bind, I do not know if this will cause problems for other debian based distros.
