### PR TITLE
this package is needed on Debian/Ubuntu for dnssec to work, or else: 'pi...

### DIFF
--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -1,6 +1,6 @@
 {% set map = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['bind9', 'bind9utils'],
+        'pkgs': ['bind9', 'bind9utils', 'dnssec-tools'],
         'service': 'bind9',
         'config': '/etc/bind/named.conf',
         'local_config': '/etc/bind/named.conf.local',


### PR DESCRIPTION
...d': 30370, 'retcode': 127, 'stderr': '/bin/bash: zonesigner: command not found', 'stdout': '