### PR TITLE
should use the signed file in named.config.local if dnssec

### DIFF
--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -12,7 +12,11 @@
 {%- set masters = salt['pillar.get']("available_zones:" + key + ":masters") %}
 zone "{{ key }}" {
   type {{ args['type'] }};
+  {% if args['dnssec'] is defined and args['dnssec'] -%}
+  file "zones/{{ file }}.signed";
+  {% else -%}
   file "zones/{{ file }}";
+  {%- endif %}
   {% if args['allow-update'] is defined  -%}
   allow-update { {{args['allow-update']}}; };
   {%- endif %}


### PR DESCRIPTION
named.conf needs to use the signed zone file and not the plain one.
This cannot be catered for in the pillars by itself (hence the change) since pillar data is given as input for signing  by zonesigner which generates the signed file