### PR TITLE
Support lists in configuration options + other tweaks/fixes

### DIFF
--- a/bind/files/debian/named.conf
+++ b/bind/files/debian/named.conf
@@ -6,6 +6,8 @@
 //
 // If you are just adding zones, please do that in /etc/bind/named.conf.local
 
-include "/etc/bind/named.conf.key";
-include "/etc/bind/named.conf.options";
-include "/etc/bind/named.conf.local";
+include "{{ map.options_config }}";
+include "{{ map.local_config }}";
+{%- if salt['pillar.get']('bind:keys', {}) is defined %}
+include "{{ map.key_config }}";
+{% endif %}

--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -15,7 +15,7 @@ zone "{{ key }}" {
   {% else -%}
   file "zones/{{ file }}";
   {%- endif %}
-  {% if args['allow-update'] is defined  -%}
+  {% if args['allow-update'] is defined -%}
   allow-update { {{args['allow-update']}}; };
   {%- endif %}
   {%- if args.update_policy is defined %}
@@ -23,7 +23,7 @@ zone "{{ key }}" {
   {%-   for policy in args.update_policy %}
     {{ policy }};
   {%- endfor %}
-  };    
+  };
   {%- endif %}
   {% if args['type'] == "master" -%}
     {% if args['notify'] -%}
@@ -38,11 +38,11 @@ zone "{{ key }}" {
 };
 {%- endmacro %}
 
-{%- if not pillar.bind.configured_views is defined %}
-include "/etc/bind/named.conf.default-zones";
+{%- if salt['pillar.get']('bind:configured_views', {}) is not defined %}
+include "{{ map.default_zones_config }}";
 {%- endif %}
 
-{% for key,args in salt['pillar.get']('bind:configured_zones', {}).iteritems()  -%}
+{% for key, args in salt['pillar.get']('bind:configured_zones', {}).iteritems() -%}
 {%- set file = salt['pillar.get']("bind:available_zones:" + key + ":file") %}
 {%- set masters = salt['pillar.get']("bind:available_zones:" + key + ":masters") %}
 {{ zone(key, args, file, masters) }}
@@ -50,18 +50,18 @@ include "/etc/bind/named.conf.default-zones";
 
 {% for view, view_data in salt['pillar.get']('bind:configured_views', {}).iteritems() %}
 
-view {{ view }}{
-{%-   if view == 'default' %}
-  include "/etc/bind/named.conf.default-zones";
+view {{ view }} {
+{%- if view == 'default' %}
+  include "{{ map.default_zones_config }}";
 {%- endif %}
 
-match-clients{
+match-clients {
 {%- for acl in view_data.get('match_clients', {}) %}
   {{ acl }};
 {%- endfor %}
 };
 
-{% for key,args in view_data.get('configured_zones', {}).iteritems()  -%}
+{% for key, args in view_data.get('configured_zones', {}).iteritems() -%}
 {%- set file = salt['pillar.get']("bind:available_zones:" + key + ":file") %}
 {%- set masters = salt['pillar.get']("bind:available_zones:" + key + ":masters") %}
   {{ zone(key, args, file, masters) }}
@@ -70,6 +70,9 @@ match-clients{
 {%- endfor %}
 
 logging {
-  channel "querylog" { file "{{ map.log_dir }}/query.log"; print-time yes; };
+  channel "querylog" {
+    file "{{ map.log_dir }}/query.log";
+    print-time yes;
+  };
   category queries { querylog; };
 };

--- a/bind/files/debian/named.conf.options
+++ b/bind/files/debian/named.conf.options
@@ -15,12 +15,21 @@ options {
         // };
 
         auth-nxdomain no;    # conform to RFC1035
-        {% if salt['pillar.get']('bind:config:ipv6', 'False') %}
-        listen-on-v6 { {{ salt['pillar.get']('bind:config:ipv6_listen', 'any') }}; };
-        {% endif -%}
 
-        {# Allow inclusion of arbitrary statements -#}
-        {% for statement, value in salt['pillar.get']('bind:config:options', {}).iteritems() -%}
-        {{ statement }} {{ value}}
-        {% endfor -%}
+{%- if salt['pillar.get']('bind:config:ipv6', False) %}
+        listen-on-v6 { {{ salt['pillar.get']('bind:config:ipv6_listen', 'any') }}; };
+{%- endif -%}
+
+{#- Allow inclusion of arbitrary statements #}
+{%- for statement, value in salt['pillar.get']('bind:config:options', {}).iteritems() -%}
+    {%- if value is iterable and value is not string %}
+        {{ statement }} {
+        {%- for item in value %}
+              {{ item }};
+        {%- endfor %}
+        };
+    {%- else %}
+        {{ statement }} {{ value }};
+    {%- endif %}
+{%- endfor %}
 };

--- a/bind/files/redhat/named.conf
+++ b/bind/files/redhat/named.conf
@@ -41,5 +41,5 @@ zone "." IN {
 };
 
 include "/etc/named.rfc1912.zones";
-include "/etc/named.conf.local";
+include "{{ map.local_config }}";
 include "/etc/named.root.key";

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -2,6 +2,7 @@
     'Debian': {
         'pkgs': ['bind9', 'bind9utils', 'dnssec-tools'],
         'service': 'bind9',
+        'config_source_dir': 'bind/files/debian',
         'config': '/etc/bind/named.conf',
         'local_config': '/etc/bind/named.conf.local',
         'key_config': '/etc/bind/named.conf.key',
@@ -10,17 +11,20 @@
         'named_directory': '/var/cache/bind/zones',
         'log_dir': '/var/log/bind9',
         'user': 'root',
-        'group': 'bind'
+        'group': 'bind',
+        'mode': '644'
     },
     'RedHat': {
         'pkgs': ['bind'],
         'service': 'named',
+        'config_source_dir': 'bind/files/redhat',
         'config': '/etc/named.conf',
         'local_config': '/etc/named.conf.local',
         'named_directory': '/var/named/data',
         'log_dir': '/var/log/named',
         'user': 'root',
-        'group': 'named'
+        'group': 'named',
+        'mode': '640'
     },
 }, merge=salt['grains.filter_by']({
     'Ubuntu': {


### PR DESCRIPTION
Simplified/unified some of the config state definitions. Added logic to automatically convert lists in pillar data to lists of configuration data for options.