### PR TITLE
Fetch user from lookup table for static defaults (map.jinja)

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -20,7 +20,7 @@ bind_restart:
 
 {{ map.log_dir }}/query.log:
   file.managed:
-    - user: bind
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
     - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
     - mode: 644
     - require:


### PR DESCRIPTION
User 'bind' does not exist in RHEL/CentOS.