### PR TITLE
Fix pillar.example: service name value is not a list

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -2,8 +2,7 @@ bind:
   lookup:
     pkgs:
       - bind
-    service:
-      - named
+    service: named
 
 bind:
   config:


### PR DESCRIPTION
- Change bind:lookup:service to a simple value in `pillar.example`.