### PR TITLE
dirty value in /etc/default/bind9

### DIFF
--- a/bind/files/debian/default
+++ b/bind/files/debian/default
@@ -1,7 +1,7 @@
 {% set protocol = salt['pillar.get']('bind:config:protocol', False) -%}
 {% set param = ['-u bind'] -%}
 {% if protocol -%}
-  {{ param.append('-' + protocol|string) }}
+  {% do param.append('-' + protocol|string) -%}
 {% endif -%}
 # run resolvconf?
 RESOLVCONF=no


### PR DESCRIPTION
when bind.config.protocol is set in pillar, "None" is returned by  param.append('-' + protocol|string) statement and written in /etc/default/bind9.
This breaks bind9 at start