### PR TITLE
Do not spec dnssec-tools for installation on Debian Jessie.

### DIFF
--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -44,8 +44,12 @@
         'mode': '640'
     },
 }, merge=salt['grains.filter_by']({
+    'jessie': {
+        'pkgs': ['bind9', 'bind9utils'],
+    },
+}, grain='oscodename', merge=salt['grains.filter_by']({
     'Ubuntu': {
         'log_dir': '/var/log/named',
         'user': 'bind'
     },
-}, grain='os', merge=salt['pillar.get']('bind:lookup'))) %}
+}, grain='os', merge=salt['pillar.get']('bind:lookup')))) %}


### PR DESCRIPTION
Due to [issues with `rollerd`][1], `dnssec-tools` was [removed from
testing][2] and did not make it into Debian Jessie.  This removes that
package spec from the formula and leaves it as an exercise to the user
to solve how to satisfy the requirement.

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=754704
[2]: https://packages.qa.debian.org/d/dnssec-tools/news/20140812T163915Z.html

Fixes #56 