### PR TITLE
added 'forward ( only | first );' support for named.conf.local

### DIFF
--- a/bind/files/arch/named.conf.local
+++ b/bind/files/arch/named.conf.local
@@ -12,10 +12,13 @@
 zone "{{ key }}" {
   type {{ args['type'] }};
   {% if args['type'] == 'forward' -%}
+    {% if args['forward'] is defined -%}
+       forward {{ args['forward'] }};
+    {%- endif %}
   forwarders {
     {% for forwarder in args.forwarders -%}
       {{ forwarder }};
-    {% endfor -%}
+    {%- endfor %}
   };
   {% else -%}
   file "{{ file }}";

--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -11,10 +11,13 @@
 zone "{{ key }}" {
   type {{ args['type'] }};
   {% if args['type'] == 'forward' -%}
+    {% if args['forward'] is defined -%}
+       forward {{ args['forward'] }};
+    {%- endif %}
   forwarders {
     {% for forwarder in args.forwarders -%}
       {{ forwarder }};
-    {% endfor -%}
+    {%- endfor %}
   };
   {% else -%}
   {% if args['dnssec'] is defined and args['dnssec'] -%}

--- a/bind/files/redhat/named.conf.local
+++ b/bind/files/redhat/named.conf.local
@@ -12,10 +12,13 @@
 zone "{{ key }}" {
   type {{ args['type'] }};
   {% if args['type'] == 'forward' -%}
+    {% if args['forward'] is defined -%}
+       forward {{ args['forward'] }};
+    {%- endif %}
   forwarders {
     {% for forwarder in args.forwarders -%}
       {{ forwarder }};
-    {% endfor -%}
+    {%- endfor %}
   };
   {% else -%}
   file "data/{{ file }}";

--- a/pillar.example
+++ b/pillar.example
@@ -47,6 +47,12 @@ bind:
       forwarders:
         - 10.9.8.7
         - 10.9.8.5
+    sub.forwardonlydomain.com:
+      type: forward
+      forward: only
+      forwarders:
+        - 10.9.8.8
+        - 10.9.8.9
   configured_views:
     myview1:
       match_clients:


### PR DESCRIPTION
Adding support for _forwarding strategy_ in _zone_ stanzas of named.conf.local file 
when **zone type** is **forward**

> forward ( only | first );

see: http://www.zytrax.com/books/dns/ch7/queries.html#forward