### PR TITLE
allow-transfer rendered only if defined

### DIFF
--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -25,7 +25,6 @@ zone "{{ key }}" {
   {% else -%}
   file "{{ map.named_directory }}/{{ file }}";
   {%- endif %}
-
   {% if args['allow-update'] is defined -%}
   allow-update { {{args['allow-update']}}; };
   {%- endif %}
@@ -36,11 +35,13 @@ zone "{{ key }}" {
   {%- endfor %}
   };
   {%- endif %}
+  {%- if args['allow-transfer'] is defined -%}
   allow-transfer {
-  {% for remote in args.get('allow-transfer', {}) %}
+  {%- for remote in args.get('allow-transfer', {}) -%}
     {{ remote }};
-  {% endfor %}
+  {%- endfor -%}
   };
+  {%- endif -%}
   {% if args['type'] == "master" -%}
     {% if args['notify'] -%}
   notify yes;


### PR DESCRIPTION
render allow-transfer sub-section only if defined pillar at zone level in order to avoid an empty "allow-transfer { } " section in named.conf.local file
A minor change to get aligned zone stanzas in named.conf.local also done.