### PR TITLE
Make some named.conf.local template whitespace cleaner

### DIFF
--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -25,7 +25,7 @@ zone "{{ key }}" {
   {% else -%}
   file "{{ map.named_directory }}/{{ file }}";
   {%- endif %}
-  {% if args['allow-update'] is defined -%}
+  {%- if args['allow-update'] is defined %}
   allow-update { {{args['allow-update']}}; };
   {%- endif %}
   {%- if args.update_policy is defined %}
@@ -35,20 +35,16 @@ zone "{{ key }}" {
   {%- endfor %}
   };
   {%- endif %}
-  {%- if args['allow-transfer'] is defined -%}
-  allow-transfer {
-  {%- for remote in args.get('allow-transfer', {}) -%}
-    {{ remote }};
-  {%- endfor -%}
-  };
-  {%- endif -%}
-  {% if args['type'] == "master" -%}
-    {% if args['notify'] -%}
+  {%- if args['allow-transfer'] is defined %}
+  allow-transfer { {{ args.get('allow-transfer', []) | join('; ') }}; };
+  {%- endif %}
+  {%- if args['type'] == "master" -%}
+    {% if args['notify'] %}
   notify yes;
-    {% else -%}
+    {% else %}
   notify no;
     {%- endif -%}
-  {% else -%}
+  {% else %}
   notify no;
   masters { {{ masters }} };
   {%- endif %}


### PR DESCRIPTION
Currently a zone clause in a rendered named.conf.local with allow-transfer, allow-update, update-policy and notify options (in appropriate combinations) looks as follows:
```
zone "int.test.com" {
  type master;
  file "/var/cache/bind/zones/db.int.test.com";
  allow-update { ddns_update_subnets; };allow-transfer {slaves;more_slaves;};notify no;
};
... snip ...
zone "1.1.1.in-addr.arpa" {
  type master;
  file "/var/cache/bind/zones/rev.1.1.1.in-addr.arpa";

  update-policy {
    local;
  };allow-transfer {slaves;more_slaves;};notify no;
};
```

With attached commit, it would look like so, a bit cleaner:
```
zone "int.test.com" {
  type master;
  file "/var/cache/bind/zones/db.int.test.com";
  allow-update { ddns_update_subnets; };
  allow-transfer { slaves; more_slaves; };
  notify no;
};
... snip ...
zone "1.1.1.in-addr.arpa" {
  type master;
  file "/var/cache/bind/zones/rev.1.1.1.in-addr.arpa";
  update-policy {
    local;
  };
  allow-transfer { slaves; more_slaves; };
  notify no;
};
```