### PR TITLE
Add documentation to pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,82 +1,102 @@
+# Note - Each section beginning with 'bind:' below represents a different way you may configure
+         pillars for bind. When configuring your pillar(s), you may use any combination of subsections,
+         but salt will not merge sections with the same heading.
+
+
+### Overrides for the defaults specified by ###
+### map.jinja                               ###
 bind:
   lookup:
     pkgs:
-      - bind
-    service: named
-    # take zonefiles from `salt://bind/zonedata`
-    # instead of `salt://zones`:
-    zones_source_dir: bind/zonedata
+      - bind                                      # Need to install
+    service: named                                # Service name
 
+    zones_source_dir: bind/zonedata               # Take zonefiles from `salt://bind/zonedata`
+                                                  # instead of `salt://zones`
+
+
+### General config options                  ###
 bind:
   config:
-    tmpl: salt://bind/files/debian/named.conf
-    user: root
-    group: named
-    mode: 640
+    tmpl: salt://bind/files/debian/named.conf     # Template we'd like to use (not implemented?)
+    user: root                                    # File & Directory user
+    group: named                                  # File & Directory group
+    mode: 640                                     # File & Directory mode
     options:
-      allow-recursion: '{ any; }'  # Never include this on a public resolver
+      allow-recursion: '{ any; }'                 # Never include this on a public resolver
 
-    # force bind to serve only one IP protocol (ipv4: 4, ipv6: 6). omitting this reverts to binds default of both.
-    protocol: 4
+    protocol: 4                                   # Force bind to serve only one IP protocol
+                                                  # (ipv4: 4, ipv6: 6). Omitting this reverts to
+                                                  # binds default of both.
 
-    # For Debian based systems:
-    # If set to True, the default-zones configuration will be enabled. Defaults to False.
-    default_zones: True
-    # For Debian based systems:
-    # Include any additional configuration file(s) in named.conf
-    includes:
-      - /some/additional/named.conf
+# Debian based systems
+    default_zones: True                           # If set to True, the default-zones configuration
+                                                  # will be enabled. Defaults to False.
 
+    includes:                                     # Include any additional configuration file(s) in
+      - /some/additional/named.conf               # named.conf
+
+# End Debian based systems
+
+### Keys, Zones, ACLs and Views             ###
 bind:
   keys:
-    "core_dhcp":
-      secret: "YourSecretKey"
+    "core_dhcp":                                  # The name for our key
+      secret: "YourSecretKey"                     # The key its self
+
   configured_zones:
-    sub.domain.com:
-      type: master
-      notify: False
-      also-notify:
+    sub.domain.com:                               # First domain zone
+      type: master                                # We're the master of this zone
+      notify: False                               # Don't notify any NS RRs of any changes to zone
+      also-notify:                                # Do notify these IP addresses (pointless as
+        - 1.1.1.1                                 # notify has been set to no)
+        - 2.2.2.2
+
+    1.168.192.in-addr.arpa:                       # Reverse lookup for local IPs
+      type: master                                # As above
+      notify: False                               # As above
+      allow-transfer:                             # As above
         - 1.1.1.1
         - 2.2.2.2
-    1.168.192.in-addr.arpa:
-      type: master
-      notify: False
-      allow-transfer:
-        - 1.1.1.1
-        - 2.2.2.2
-    dynamic.domain.com:
-      type: master
-      allow-update: "key core_dhcp"
-      notify: True
-    sub.anotherdomain.com:
-      type: forward
-      forwarders:
+
+    dynamic.domain.com:                           # Our ddns zone
+      type: master                                # As above
+      allow-update: "key core_dhcp"               # Who we allow updates from (refers to above key)
+      notify: True                                # Notify NS RRs of changes
+
+    sub.anotherdomain.com:                        # Another domain zone
+      type: forward                               # This time it's a forwarding zone
+      forwarders:                                 # Where we need to forward requests to
         - 10.9.8.7
         - 10.9.8.5
-    sub.forwardonlydomain.com:
-      type: forward
-      forward: only
-      forwarders:
+
+    sub.forwardonlydomain.com:                    # Forwarding only domain
+      type: forward                               # As above
+      forward: only                               # We don't want the server to do any resulving
+      forwarders:                                 # As above (but with different IPs)
         - 10.9.8.8
         - 10.9.8.9
+
   configured_views:
-    myview1:
-      match_clients:
+    myview1:                                      # First (and only) view
+      match_clients:                              # The clients we wish to match
         - client1
         - client2
-      configured_zones:
-        my.zone:
+      configured_zones:                           # Zones that our view is applicable to
+        my.zone:                                  # We've defined a new zone in here
           type: master
           notify: False
-          update_policy:
+          update_policy:                          # A given update policy
             - "grant core_dhcp name dns_entry_allowed_to_update. ANY"
-  configured_acls:
-    my_net:
-      - 127.0.0.0/8
+
+  configured_acls:                                # And now for some ACLs
+    my_net:                                       # Our ACL's name
+      - 127.0.0.0/8                               # And the applicable IP addresses
       - 10.20.0.0/16
 
+### Externally defined Zones ###
 bind:
   available_zones:
     sub.domain.org:
-      file: db.sub.domain.org
-      masters: "192.168.0.1;"
+      file: db.sub.domain.org                     # DB file containing our zone
+      masters: "192.168.0.1;"                     # Masters of this zone


### PR DESCRIPTION
As per Issue #32 , documentation has been added to better explain that each
section with a "bind:" heading is a separate section with different
features described. Comments have also been added to describe what
different parts of the config actually do.