### PR TITLE
Fixes issue where query.log throws warning for replace=True

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -23,6 +23,7 @@ bind_restart:
     - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
     - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
     - mode: {{ salt['pillar.get']('bind:config:log_mode', map.log_mode) }}
+    - replace: False
     - require:
       - file: {{ map.log_dir }}
 


### PR DESCRIPTION
Fixes issue where file.managed is used to create an empty file without `source`/`contents_pillar`/`contents_grains`.

```
[WARNING ] State for file: /var/log/bind9/query.log - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
```