### PR TITLE
RedHat: Allow options to be overriden and keys to be defined

### DIFF
--- a/bind/files/redhat/named.conf
+++ b/bind/files/redhat/named.conf
@@ -7,25 +7,37 @@
 // See /usr/share/doc/bind*/sample/ for example named configuration files.
 //
 
+{#- Redhat default configuration #}
+{%- set options = {
+    'listen-on': 'port 53 { any; }',
+    'listen-on-v6': 'port 53 { ::1; }',
+    'directory': '"/var/named"',
+    'dump-file': '"/var/named/data/cache_dump.db"',
+    'statistics-file': '"/var/named/data/named_stats.txt"',
+    'memstatistics-file': '"/var/named/data/named_mem_stats.txt"',
+    'allow-query': '{ any; }',
+    'recursion': 'yes',
+    'dnssec-enable': 'yes',
+    'dnssec-validation': 'yes',
+    'dnssec-lookaside': 'auto',
+    'bindkeys-file': '"/etc/named.iscdlv.key"',
+    'managed-keys-directory': '"/var/named/dynamic"'
+} -%}
+{%- do options.update(salt['pillar.get']('bind:config:options', {})) %}
+
 options {
-        //listen-on port 53 { 127.0.0.1; };
-        listen-on port 53 { any; };
-        listen-on-v6 port 53 { ::1; };
-        directory       "/var/named";
-        dump-file       "/var/named/data/cache_dump.db";
-        statistics-file "/var/named/data/named_stats.txt";
-        memstatistics-file "/var/named/data/named_mem_stats.txt";
-        allow-query     { any; };
-        recursion yes;
-
-        dnssec-enable yes;
-        dnssec-validation yes;
-        dnssec-lookaside auto;
-
-        /* Path to ISC DLV key */
-        bindkeys-file "/etc/named.iscdlv.key";
-
-        managed-keys-directory "/var/named/dynamic";
+    {#- Allow inclusion of arbitrary statements #}
+    {%- for statement, value in options.items() -%}
+        {%- if value is iterable and value is not string %}
+            {{ statement }} {
+            {%- for item in value %}
+                  {{ item }};
+            {%- endfor %}
+            };
+        {%- else %}
+    {{ statement }} {{ value }};
+        {%- endif %}
+    {%- endfor %}
 };
 
 logging {
@@ -40,6 +52,18 @@ zone "." IN {
         file "named.ca";
 };
 
+{% if 'keys' in salt['pillar.get']('bind') -%}
+{%- for key,args in salt['pillar.get']('bind:keys', {}).items()  -%}
+key "{{ key }}" {
+  algorithm {{ args['algorithm'] | default('HMAC-MD5.SIG-ALG.REG.INT') }};
+  secret "{{ args['secret'] }}";
+};
+{%- endfor %}
+{%- endif %}
+
 include "/etc/named.rfc1912.zones";
 include "{{ map.local_config }}";
 include "/etc/named.root.key";
+{%- for incl in salt['pillar.get']('bind:config:includes', []) %}
+include "{{ incl }}";
+{% endfor %}


### PR DESCRIPTION
This formula only allows Redhat to have the default options defined in named.conf, options and keys are currently ignored on Redhat systems.

This change will allow you to override and set options and keys on RedHat