### PR TITLE
Redhat config update

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -132,7 +132,7 @@ bind_default_zones:
 {% endif %}
 
 {% for zone, zone_data in salt['pillar.get']('bind:configured_zones', {}).items() -%}
-{%- set file = salt['pillar.get']("bind:available_zones:" + zone + ":file") %}
+{%- set file = salt['pillar.get']("bind:available_zones:" + zone + ":file", zone_data.get('file')) %}
 {% if file and zone_data['type'] == "master" -%}
 zones-{{ zone }}:
   file.managed:
@@ -161,7 +161,7 @@ signed-{{ zone }}:
 
 {%- for view, view_data in salt['pillar.get']('bind:configured_views', {}).items() %}
 {% for zone, zone_data in view_data.get('configured_zones', {}).items() -%}
-{%- set file = salt['pillar.get']("bind:available_zones:" + zone + ":file") %}
+{%- set file = salt['pillar.get']("bind:available_zones:" + zone + ":file", zone_data.get('file')) %}
 {% if file and zone_data['type'] == "master" -%}
 zones-{{ view }}-{{ zone }}:
   file.managed:

--- a/bind/config.sls
+++ b/bind/config.sls
@@ -20,6 +20,7 @@ bind_restart:
 
 {{ map.log_dir }}/query.log:
   file.managed:
+    - replace: False
     - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
     - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
     - mode: {{ salt['pillar.get']('bind:config:log_mode', map.log_mode) }}

--- a/bind/files/redhat/named.conf
+++ b/bind/files/redhat/named.conf
@@ -48,7 +48,7 @@ logging {
         {%- endif %}
 {%- endfor %}
 
-{%- for statement, value in salt['pillar.get']('bind:config:logging:category', {}).items() -%}
+{%- for statement, value in salt['pillar.get']('bind:config:logging:category', {}).items() %}
         category {{ statement }} {
         {%- for item in value %}
                 {{ item }};

--- a/bind/files/redhat/named.conf
+++ b/bind/files/redhat/named.conf
@@ -14,11 +14,11 @@ options {
         memstatistics-file "/var/named/data/named_mem_stats.txt";
 
 {#- Allow inclusion of arbitrary statements #}
-{%- for statement, value in salt['pillar.get']('bind:config:options', {}).items() -%}
+{%- for statement, value in salt['pillar.get']('bind:config:options', map.get('options', {})).items() -%}
     {%- if value is iterable and value is not string %}
         {{ statement }} {
         {%- for item in value %}
-              {{ item }};
+                {{ item }};
         {%- endfor %}
         };
     {%- else %}
@@ -37,6 +37,39 @@ logging {
                 file "data/named.run";
                 severity dynamic;
         };
+
+{%- for channel, value in salt['pillar.get']('bind:config:logging:channels', {}).items() -%}
+        {%- if value is iterable %}
+        channel {{ channel }} {
+        {%- for statement, item in value.items() %}
+                {{ statement }} {{ item }};
+        {%- endfor %}
+        };
+        {%- endif %}
+{%- endfor %}
+
+{%- for statement, value in salt['pillar.get']('bind:config:logging:category', {}).items() -%}
+        category {{ statement }} {
+        {%- for item in value %}
+                {{ item }};
+        {%- endfor %}
+        };
+{%- endfor %}
+
+{%- for statement, value in salt['pillar.get']('bind:config:logging', {}).items() -%}
+    {%- if statement not in ( 'channels', 'category' ) %}
+    {%- if value is iterable and value is not string %}
+        {{ statement }} {
+        {%- for item in value %}
+                {{ item }};
+        {%- endfor %}
+        };
+    {%- else %}
+        {{ statement }} {{ value }};
+    {%- endif %}
+    {%- endif %}
+{%- endfor %}
+
 };
 
 zone "." IN {

--- a/bind/files/redhat/named.conf
+++ b/bind/files/redhat/named.conf
@@ -8,19 +8,23 @@
 //
 
 options {
-        //listen-on port 53 { 127.0.0.1; };
-        listen-on port 53 { any; };
-        listen-on-v6 port 53 { ::1; };
         directory       "/var/named";
         dump-file       "/var/named/data/cache_dump.db";
         statistics-file "/var/named/data/named_stats.txt";
         memstatistics-file "/var/named/data/named_mem_stats.txt";
-        allow-query     { any; };
-        recursion yes;
 
-        dnssec-enable yes;
-        dnssec-validation yes;
-        dnssec-lookaside auto;
+{#- Allow inclusion of arbitrary statements #}
+{%- for statement, value in salt['pillar.get']('bind:config:options', {}).items() -%}
+    {%- if value is iterable and value is not string %}
+        {{ statement }} {
+        {%- for item in value %}
+              {{ item }};
+        {%- endfor %}
+        };
+    {%- else %}
+        {{ statement }} {{ value }};
+    {%- endif %}
+{%- endfor %}
 
         /* Path to ISC DLV key */
         bindkeys-file "/etc/named.iscdlv.key";

--- a/bind/files/redhat/named.conf.local
+++ b/bind/files/redhat/named.conf.local
@@ -6,9 +6,7 @@
 // organization
 //include "/etc/bind/zones.rfc1918";
 
-{% for key,args in salt['pillar.get']('bind:configured_zones', {}).items()  -%}
-{%- set file = salt['pillar.get']("bind:available_zones:" + key + ":file") %}
-{%- set masters = salt['pillar.get']("bind:available_zones:" + key + ":masters") %}
+{%- macro zone(key, args, file, masters) %}
 zone "{{ key }}" {
   type {{ args['type'] }};
   {% if args['type'] == 'forward' -%}
@@ -21,20 +19,64 @@ zone "{{ key }}" {
     {%- endfor %}
   };
   {% else -%}
-  file "data/{{ file }}";
+  {% if args['dnssec'] is defined and args['dnssec'] -%}
+  file "{{ map.named_directory }}/{{ file }}.signed";
+  {% else -%}
+  file "{{ map.named_directory }}/{{ file }}";
+  {%- endif %}
+  {%- if args['allow-update'] is defined %}
+  allow-update { {{args['allow-update']}}; };
+  {%- endif %}
+  {%- if args.update_policy is defined %}
+  update-policy {
+  {%-   for policy in args.update_policy %}
+    {{ policy }};
+  {%- endfor %}
+  };
+  {%- endif %}
+  {%- if args['allow-transfer'] is defined %}
+  allow-transfer { {{ args.get('allow-transfer', []) | join('; ') }}; };
+  {%- endif %}
   {%- if args['also-notify'] is defined %}
   also-notify { {{ args.get('also-notify', []) | join('; ') }}; };
   {%- endif %}
-  {% if args['type'] == "master" -%}
-    {% if args['notify'] -%}
+  {%- if args['type'] == 'slave' %}
+    {%- if args['allow-notify'] is defined %}
+  allow-notify { {{ args.get('allow-notify', []) | join('; ') }}; };
+    {%- endif %}
+  {%- endif %}
+  {%- if args['type'] == "master" -%}
+    {% if args['notify'] %}
   notify yes;
-    {% else -%}
+    {% else %}
   notify no;
     {%- endif -%}
-  {% else -%}
+  {% else %}
   notify no;
+    {%- if masters is iterable and masters is not string %}
+  masters {
+      {%- for item in masters %}
+            {{ item }};
+      {%- endfor %}
+  };
+    {%- else %}
   masters { {{ masters }} };
+    {%- endif %}
   {%- endif %}
   {%- endif %}
 };
+{%- endmacro %}
+
+{% for key, args in salt['pillar.get']('bind:configured_zones', {}).items() -%}
+{%- set file = args.get('file', salt['pillar.get']("bind:available_zones:" + key + ":file")) %}
+{%- set masters = args.get('masters', salt['pillar.get']("bind:available_zones:" + key + ":masters")) %}
+{{ zone(key, args, file, masters) }}
 {% endfor %}
+
+{%- for name, data in salt['pillar.get']('bind:configured_acls', {}).items() %}
+acl {{ name }} {
+  {%- for d in data %}
+  {{ d }};
+  {%- endfor %}
+};
+{%- endfor %}

--- a/bind/files/redhat/named.conf.local
+++ b/bind/files/redhat/named.conf.local
@@ -7,7 +7,7 @@
 //include "/etc/bind/zones.rfc1918";
 
 {%- macro zone(key, args, file, masters) %}
-zone "{{ key }}" {
+zone "{{ key }}" IN {
         type {{ args['type'] }};
   {% if args['type'] == 'forward' -%}
     {% if args['forward'] is defined -%}

--- a/bind/files/redhat/named.conf.local
+++ b/bind/files/redhat/named.conf.local
@@ -8,59 +8,59 @@
 
 {%- macro zone(key, args, file, masters) %}
 zone "{{ key }}" {
-  type {{ args['type'] }};
+        type {{ args['type'] }};
   {% if args['type'] == 'forward' -%}
     {% if args['forward'] is defined -%}
-       forward {{ args['forward'] }};
+        forward {{ args['forward'] }};
     {%- endif %}
-  forwarders {
+        forwarders {
     {% for forwarder in args.forwarders -%}
-      {{ forwarder }};
+                {{ forwarder }};
     {%- endfor %}
   };
   {% else -%}
   {% if args['dnssec'] is defined and args['dnssec'] -%}
-  file "{{ map.named_directory }}/{{ file }}.signed";
+        file "{{ file }}.signed";
   {% else -%}
-  file "{{ map.named_directory }}/{{ file }}";
+        file "{{ file }}";
   {%- endif %}
   {%- if args['allow-update'] is defined %}
-  allow-update { {{args['allow-update']}}; };
+        allow-update { {{args['allow-update']}}; };
   {%- endif %}
   {%- if args.update_policy is defined %}
-  update-policy {
+        update-policy {
   {%-   for policy in args.update_policy %}
-    {{ policy }};
+                {{ policy }};
   {%- endfor %}
-  };
+        };
   {%- endif %}
   {%- if args['allow-transfer'] is defined %}
-  allow-transfer { {{ args.get('allow-transfer', []) | join('; ') }}; };
+        allow-transfer { {{ args.get('allow-transfer', []) | join('; ') }}; };
   {%- endif %}
   {%- if args['also-notify'] is defined %}
-  also-notify { {{ args.get('also-notify', []) | join('; ') }}; };
+        also-notify { {{ args.get('also-notify', []) | join('; ') }}; };
   {%- endif %}
   {%- if args['type'] == 'slave' %}
     {%- if args['allow-notify'] is defined %}
-  allow-notify { {{ args.get('allow-notify', []) | join('; ') }}; };
+        allow-notify { {{ args.get('allow-notify', []) | join('; ') }}; };
     {%- endif %}
   {%- endif %}
   {%- if args['type'] == "master" -%}
     {% if args['notify'] %}
-  notify yes;
+        notify yes;
     {% else %}
-  notify no;
+        notify no;
     {%- endif -%}
   {% else %}
-  notify no;
+        notify no;
     {%- if masters is iterable and masters is not string %}
-  masters {
+        masters {
       {%- for item in masters %}
-            {{ item }};
+                {{ item }};
       {%- endfor %}
-  };
+        };
     {%- else %}
-  masters { {{ masters }} };
+        masters { {{ masters }} };
     {%- endif %}
   {%- endif %}
   {%- endif %}
@@ -76,7 +76,7 @@ zone "{{ key }}" {
 {%- for name, data in salt['pillar.get']('bind:configured_acls', {}).items() %}
 acl {{ name }} {
   {%- for d in data %}
-  {{ d }};
+        {{ d }};
   {%- endfor %}
 };
 {%- endfor %}

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -25,7 +25,7 @@
         'config': '/etc/named.conf',
         'local_config': '/etc/named.conf.local',
         'default_config': '/etc/sysconfig/named',
-        'named_directory': '/var/named/data',
+        'named_directory': '/var/named',
         'log_dir': '/var/log/named',
         'log_mode': '640',
         'user': 'root',

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -30,7 +30,15 @@
         'log_mode': '640',
         'user': 'root',
         'group': 'named',
-        'mode': '640'
+        'mode': '640',
+        'options': {
+          'listen-on': 'port 53 { 127.0.0.1; }',
+          'listen-on-v6': 'port 53 { ::1; }',
+          'allow-query': '{ localhost; }',
+          'recursion': 'yes',
+          'dnssec-enable': 'yes',
+          'dnssec-validation': 'yes'
+        }
     },
     'Arch': {
         'pkgs': ['bind', 'bind-tools', 'dnssec-tools'],

--- a/pillar.example
+++ b/pillar.example
@@ -24,6 +24,14 @@ bind:
     mode: 640                                     # File & Directory mode
     options:
       allow-recursion: '{ any; }'                 # Never include this on a public resolver
+# RedHat defaults, needed to generate default config file
+      listen-on: 'port 53 { 127.0.0.1; }'
+      listen-on-v6: 'port 53 { ::1; }'
+      allow-query: '{ localhost; }'
+      recursion: 'yes'
+      dnssec-enable: 'yes'
+      dnssec-validation: 'yes'
+# End RedHat defaults
 
     protocol: 4                                   # Force bind to serve only one IP protocol
                                                   # (ipv4: 4, ipv6: 6). Omitting this reverts to
@@ -37,6 +45,7 @@ bind:
       - /some/additional/named.conf               # named.conf
 
 # End Debian based systems
+
 
 ### Keys, Zones, ACLs and Views             ###
 bind:


### PR DESCRIPTION
- Configuration files templates and default values update for RedHat
- 'replace' flag set to 'False' in query.log state due to Salt complains