### PR TITLE
Support list of `masters` in `named.conf.local` template

### DIFF
--- a/bind/files/arch/named.conf.local
+++ b/bind/files/arch/named.conf.local
@@ -35,7 +35,15 @@ zone "{{ key }}" {
     {%- endif -%}
   {% else %}
   notify no;
-  masters { {{ masters }} };
+  {%- if masters is iterable and masters is not string %}
+  masters {
+    {%- for item in masters %}
+    {{ item }};
+    {%- endfor %}
+  };
+  {%- else %}
+    masters { {{ masters }} };
+  {%- endif %}
   {%- endif %}
   {%- endif %}
 };

--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -49,7 +49,15 @@ zone "{{ key }}" {
     {%- endif -%}
   {% else %}
   notify no;
-  masters { {{ masters }} };
+  {%- if masters is iterable and masters is not string %}
+  masters {
+    {%- for item in masters %}
+    {{ item }};
+    {%- endfor %}
+  };
+  {%- else %}
+    masters { {{ masters }} };
+  {%- endif %}
   {%- endif %}
   {%- endif %}
 };

--- a/bind/files/freebsd/named.conf.local
+++ b/bind/files/freebsd/named.conf.local
@@ -49,7 +49,15 @@ zone "{{ key }}" {
     {%- endif -%}
   {% else %}
   notify no;
-  masters { {{ masters }} };
+  {%- if masters is iterable and masters is not string %}
+  masters {
+    {%- for item in masters %}
+    {{ item }};
+    {%- endfor %}
+  };
+  {%- else %}
+    masters { {{ masters }} };
+  {%- endif %}
   {%- endif %}
   {%- endif %}
 };

--- a/pillar.example
+++ b/pillar.example
@@ -108,4 +108,5 @@ bind:
   available_zones:
     sub.domain.org:
       file: db.sub.domain.org                     # DB file containing our zone
-      masters: "192.168.0.1;"                     # Masters of this zone
+      masters:                                    # Masters of this zone
+        - 192.168.0.1


### PR DESCRIPTION
Updates the archlinux, debian, freebsd templates to support passing a
list of values to `masters` instead of a string. This is already
supported by the redhat template, but lacking in the other 3.