### PR TITLE
New features and pillar.example

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -130,6 +130,23 @@ bind_default_zones:
     - group: root
     - context:
         map: {{ map }}
+
+{%- if salt['pillar.get']('bind:config:use_extensive_logging', False) %}
+bind_logging_config:
+  file.managed:
+    - name: {{ map.logging_config }}
+    - source: salt://{{ map.config_source_dir }}/named.conf.logging
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - context:
+        map: {{ map }}
+    - require:
+      - pkg: bind
+    - watch_in:
+      - service: bind
+{%- endif %}
 {% endif %}
 
 {% for zone, zone_data in salt['pillar.get']('bind:configured_zones', {}).items() -%}

--- a/bind/config.sls
+++ b/bind/config.sls
@@ -147,6 +147,20 @@ bind_logging_config:
     - watch_in:
       - service: bind
 {%- endif %}
+{%- if salt['pillar.get']('bind:rndc_client', False) %}
+bind_rndc_client_config:
+  file.managed:
+    - name: {{ map.rndc_client_config }}
+    - source: salt://{{ map.config_source_dir }}/rndc.conf
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '640') }}
+    - context:
+        map: {{ map }}
+    - require:
+      - pkg: bind
+{%- endif %}
 {% endif %}
 
 {% for zone, zone_data in salt['pillar.get']('bind:configured_zones', {}).items() -%}

--- a/bind/files/debian/named.conf.local
+++ b/bind/files/debian/named.conf.local
@@ -41,6 +41,12 @@ zone "{{ key }}" {
   {%- if args['also-notify'] is defined %}
   also-notify { {{ args.get('also-notify', []) | join('; ') }}; };
   {%- endif %}
+  {%- if args['allow-query'] is defined %}
+  allow-query { {{ args.get('allow-query', []) | join('; ') }}; };
+  {%- endif %}
+  {%- if args['zone-statistics'] is defined %}
+  zone-statistics yes;
+  {%- endif %}
   {%- if args['type'] == "master" -%}
     {% if args['notify'] %}
   notify yes;
@@ -68,8 +74,17 @@ include "{{ map.default_zones_config }}";
 {%- endif %}
 
 {% for key, args in salt['pillar.get']('bind:configured_zones', {}).items() -%}
+{%- if salt['pillar.get']("bind:configured_zones:" + key + ":file") -%}
+{%- set file = salt['pillar.get']("bind:configured_zones:" + key + ":file") %}
+{% else %}
 {%- set file = salt['pillar.get']("bind:available_zones:" + key + ":file") %}
+{%- endif -%}
+
+{%- if salt['pillar.get']("bind:configured_zones:" + key + ":masters") -%}
+{%- set masters = salt['pillar.get']("bind:configured_zones:" + key + ":masters") %}
+{% else %}
 {%- set masters = salt['pillar.get']("bind:available_zones:" + key + ":masters") %}
+{%- endif -%}
 {{ zone(key, args, file, masters) }}
 {% endfor %}
 
@@ -94,6 +109,9 @@ match-clients {
 };
 {%- endfor %}
 
+{%- if salt['pillar.get']('bind:config:use_extensive_logging', False) %}
+include "{{ map.logging_config }}";
+{% else %}
 logging {
   channel "querylog" {
     file "{{ map.log_dir }}/query.log";
@@ -101,9 +119,56 @@ logging {
   };
   category queries { querylog; };
 };
+{%- endif %}
+
+{%- if salt['pillar.get']('bind:controls', False) %}
+controls {
+    {%- for name, control in salt['pillar.get']('bind:controls').iteritems() if control.get('enabled', True) %}
+    inet {{ control.get('bind', {}).get('address', '127.0.0.1') }} port {{ control.get('bind', {}).get('port', 953) }}
+    {%- if control.get('allow') %}
+    allow {
+        {%- for allow in control.allow %}
+        {{ allow }};
+        {%- endfor %}
+    }
+    {%- endif %}
+    {%- if control.get('keys') %}
+    keys {
+        {%- for key in control.get('keys') %}
+        {{ key }};
+        {%- endfor %}
+    }
+    {%- endif %};
+    {%- endfor %}
+};
+{%- endif %}
+
+{%- if salt['pillar.get']('bind:statistics', False) %}
+statistics-channels {
+    {%- for name, channel in salt['pillar.get']('bind:statistics').iteritems() if channel.get('enabled', True) %}
+    inet {{ channel.get('bind', {}).get('address', '127.0.0.1') }} port {{ channel.get('bind', {}).get('port', 953) }}
+    {%- if channel.get('allow') %}
+    allow {
+        {%- for allow in channel.allow %}
+        {{ allow }};
+        {%- endfor %}
+    }
+    {%- endif %};
+    {%- endfor %}
+};
+{%- endif %}
+
 
 {%- for name, data in salt['pillar.get']('bind:configured_acls', {}).items() %}
 acl {{ name }} {
+  {%- for d in data %}
+  {{ d }};
+  {%- endfor %}
+};
+{%- endfor %}
+
+{%- for name, data in salt['pillar.get']('bind:configured_masters', {}).items() %}
+masters {{ name }} {
   {%- for d in data %}
   {{ d }};
   {%- endfor %}

--- a/bind/files/debian/named.conf.logging
+++ b/bind/files/debian/named.conf.logging
@@ -1,0 +1,120 @@
+
+// Configuration based on https://kb.isc.org/article/AA-01526/0/BIND-Logging-some-basic-recommendations.html
+logging {
+        channel default_log {
+                file "{{ map.log_dir }}/default" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel auth_servers_log {
+                file "{{ map.log_dir }}/auth_servers" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel dnssec_log {
+                file "{{ map.log_dir }}/dnssec" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel zone_transfers_log {
+                file "{{ map.log_dir }}/zone_transfers" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel ddns_log {
+                file "{{ map.log_dir }}/ddns" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel client_security_log {
+                file "{{ map.log_dir }}/client_security" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel rate_limiting_log {
+                file "{{ map.log_dir }}/rate_limiting" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel rpz_log {
+                file "{{ map.log_dir }}/rpz" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+
+//
+// If you have the category ‘queries’ defined, and you don’t want query logging
+// by default, make sure you add option ‘querylog no;’ - then you can toggle
+// query logging on (and off again) using command ‘rndc querylog’
+//
+        channel queries_log {
+                file "{{ map.log_dir }}/queries" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity info;
+        };
+        channel query-errors_log {
+                file "{{ map.log_dir }}/query-errors" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                severity dynamic; 
+        };
+        channel default_syslog {
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                syslog daemon;
+                severity info;
+        };
+        channel default_debug {
+                print-time yes;
+                print-category yes;
+                print-severity yes;
+                file "named.run";
+                severity dynamic;
+        };
+
+        category default { default_syslog; default_debug; default_log; };
+        category config { default_syslog; default_debug; default_log; }; 
+        category dispatch { default_syslog; default_debug; default_log; };
+        category network { default_syslog; default_debug; default_log; };
+        category general { default_syslog; default_debug; default_log; };
+        category resolver { auth_servers_log; default_debug; };
+        category cname { auth_servers_log; default_debug; };
+        category delegation-only { auth_servers_log; default_debug; };
+        category lame-servers { auth_servers_log; default_debug; };
+        category edns-disabled { auth_servers_log; default_debug; };
+        category dnssec { dnssec_log; default_debug; };
+        category notify { zone_transfers_log; default_debug; };
+        category xfer-in { zone_transfers_log; default_debug; };
+        category xfer-out { zone_transfers_log; default_debug; };
+        category update{ ddns_log; default_debug; };
+        category update-security { ddns_log; default_debug; };
+        category client{ client_security_log; default_debug; };
+        category security { client_security_log; default_debug; };
+        category rate-limit { rate_limiting_log; default_debug; };
+        category spill { rate_limiting_log; default_debug; };
+        category database { rate_limiting_log; default_debug; };
+        category rpz { rpz_log; default_debug; };
+        category queries { queries_log; };
+        category query-errors {query-errors_log; };
+
+};

--- a/bind/files/debian/named.conf.logging
+++ b/bind/files/debian/named.conf.logging
@@ -1,120 +1,33 @@
 
-// Configuration based on https://kb.isc.org/article/AA-01526/0/BIND-Logging-some-basic-recommendations.html
+
 logging {
-        channel default_log {
-                file "{{ map.log_dir }}/default" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
-        channel auth_servers_log {
-                file "{{ map.log_dir }}/auth_servers" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
-        channel dnssec_log {
-                file "{{ map.log_dir }}/dnssec" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
-        channel zone_transfers_log {
-                file "{{ map.log_dir }}/zone_transfers" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
-        channel ddns_log {
-                file "{{ map.log_dir }}/ddns" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
-        channel client_security_log {
-                file "{{ map.log_dir }}/client_security" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
-        channel rate_limiting_log {
-                file "{{ map.log_dir }}/rate_limiting" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
-        channel rpz_log {
-                file "{{ map.log_dir }}/rpz" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity info;
-        };
 
-//
-// If you have the category ‘queries’ defined, and you don’t want query logging
-// by default, make sure you add option ‘querylog no;’ - then you can toggle
-// query logging on (and off again) using command ‘rndc querylog’
-//
-        channel queries_log {
-                file "{{ map.log_dir }}/queries" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
+{% for channel in salt['pillar.get']('bind:config:use_extensive_logging:channel') %}
+        channel {{channel}} {
+{%- if salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':file', False) %}
+                file "{{ map.log_dir }}/{{salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':file')}}" versions {{salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':size', '20m')}}; 
+{%- endif %}
+{%- if salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':print-time') %}
                 print-time yes;
+{%- endif %}
+{%- if salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':print-category') %}
                 print-category yes;
+{%- endif %}
+{%- if salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':print-severity') %}
                 print-severity yes;
-                severity info;
+{%- endif %}
+{%- if salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':severity') %}
+                severity {{salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':severity')}};
+{%- endif %}
+{%- if salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':syslog') %}
+                syslog {{salt['pillar.get']('bind:config:use_extensive_logging:channel:'+channel+':syslog')}};
+{%- endif %}
         };
-        channel query-errors_log {
-                file "{{ map.log_dir }}/query-errors" versions {{salt['pillar.get']('bind:config:use_extensive_logging:versions', '3')}} size {{salt['pillar.get']('bind:config:use_extensive_logging:size', '20m')}};
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                severity dynamic; 
-        };
-        channel default_syslog {
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                syslog daemon;
-                severity info;
-        };
-        channel default_debug {
-                print-time yes;
-                print-category yes;
-                print-severity yes;
-                file "named.run";
-                severity dynamic;
-        };
+{% endfor %}
 
-        category default { default_syslog; default_debug; default_log; };
-        category config { default_syslog; default_debug; default_log; }; 
-        category dispatch { default_syslog; default_debug; default_log; };
-        category network { default_syslog; default_debug; default_log; };
-        category general { default_syslog; default_debug; default_log; };
-        category resolver { auth_servers_log; default_debug; };
-        category cname { auth_servers_log; default_debug; };
-        category delegation-only { auth_servers_log; default_debug; };
-        category lame-servers { auth_servers_log; default_debug; };
-        category edns-disabled { auth_servers_log; default_debug; };
-        category dnssec { dnssec_log; default_debug; };
-        category notify { zone_transfers_log; default_debug; };
-        category xfer-in { zone_transfers_log; default_debug; };
-        category xfer-out { zone_transfers_log; default_debug; };
-        category update{ ddns_log; default_debug; };
-        category update-security { ddns_log; default_debug; };
-        category client{ client_security_log; default_debug; };
-        category security { client_security_log; default_debug; };
-        category rate-limit { rate_limiting_log; default_debug; };
-        category spill { rate_limiting_log; default_debug; };
-        category database { rate_limiting_log; default_debug; };
-        category rpz { rpz_log; default_debug; };
-        category queries { queries_log; };
-        category query-errors {query-errors_log; };
+{%- for category in salt['pillar.get']('bind:config:use_extensive_logging:category') %}
+        category {{category}} { {{ salt['pillar.get']('bind:config:use_extensive_logging:category:'+category, []) | join('; ') }}; };
+
+{%- endfor %}
 
 };

--- a/bind/files/zone.jinja
+++ b/bind/files/zone.jinja
@@ -11,9 +11,9 @@
 {%- set zone_expiry = soa['expiry'] if soa['expiry'] is defined else '2w' %}
 {%- set zone_nxdomain = soa['nxdomain'] if soa['nxdomain'] is defined else '1m' %}
 
-{%- if soa['ttl'] is defined -%}
+{% if soa['ttl'] is defined %}
 $TTL {{ soa['ttl'] }}
-{%- endif %}
+{% endif %}
 @ {{ zone_class }} SOA {{ zone_ns }} {{ zone_contact }} (
     {{ zone_serial }} ; serial
     {{ zone_refresh }} ; refresh

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -10,12 +10,16 @@
         'options_config': '/etc/bind/named.conf.options',
         'default_config': '/etc/default/bind9',
         'default_zones_config': '/etc/bind/named.conf.default-zones',
+        'logging_config': '/etc/bind/named.conf.logging',
         'named_directory': '/var/cache/bind/zones',
         'log_dir': '/var/log/bind9',
         'log_mode': '644',
         'user': 'bind',
         'group': 'bind',
-        'mode': '644'
+        'mode': '644',
+        'options': {
+          'querylog': 'no'
+        }
     },
     'RedHat': {
         'pkgs': ['bind'],

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -11,6 +11,7 @@
         'default_config': '/etc/default/bind9',
         'default_zones_config': '/etc/bind/named.conf.default-zones',
         'logging_config': '/etc/bind/named.conf.logging',
+        'rndc_client_config': '/etc/bind/rndc.conf',
         'named_directory': '/var/cache/bind/zones',
         'log_dir': '/var/log/bind9',
         'log_mode': '644',

--- a/pillar.example
+++ b/pillar.example
@@ -32,19 +32,115 @@ bind:
       dnssec-enable: 'yes'
       dnssec-validation: 'yes'
 # End RedHat defaults
-
     protocol: 4                                   # Force bind to serve only one IP protocol
                                                   # (ipv4: 4, ipv6: 6). Omitting this reverts to
                                                   # binds default of both.
 
-# Debian and FreeBSD based systems
+# Debian and FreeBSD based systems 
     default_zones: True                           # If set to True, the default-zones configuration
                                                   # will be enabled. Defaults to False.
 
     includes:                                     # Include any additional configuration file(s) in
       - /some/additional/named.conf               # named.conf
 
-# End Debian based systems
+# Debian based systems optional configs 
+bind:
+  config:
+    options:
+      querylog: 'yes'                             # Enable query logs, by default is disabled in map.jinja (yes,no)
+
+    #use_extensive_logging: True                   # Enable extensive config for logging
+
+    use_extensive_logging:                        # Enable extensive config for logging                       
+      versions: 5                                 # Additionaly you can set how many files will be stored
+      size: '100m'                                # Maximum size of a individual file 
+
+  controls:
+    local:
+      enabled: true
+      bind:
+        address: 127.0.0.1
+        port: 953
+      allow:
+        - 127.0.0.1
+      keys:
+        - core_dhcp
+    myip4:
+      enabled: true
+      bind:
+        address: 10.161.161.168
+        port: 953
+      allow:
+        - 10.161.161.168
+        - my_net
+      keys:
+        - core_dhcp
+
+  statistics:                                        # Enable statistics-channel 
+    local:
+      enabled: true
+      bind:
+        address: 127.0.0.1
+        port: 8053
+      allow:
+        - 127.0.0.1
+    myip4:
+      enabled: true
+      bind:
+        address: 10.161.161.168
+        port: 8123
+      allow:
+        - 10.161.64.168
+        - my_net
+
+
+  configured_zones:                                  # Debian based systems can have zones using only configured_zones
+    sub.domain.com:                                  # This zone will be copied from zones_source_dir
+      file: sub.domain.com                           # You can optionally specify name fd a file for the zone here. 
+      type: master                                   # Yo don't have define zone again in available_zones. 
+                                                     # This feature is backward compatibile and only available in debian
+      notify: False                                  # if type master you need specify notify True/False
+
+    sub2.domain.com:                                 
+      file: sub2.domain.com
+      type: master
+      notify: True
+      allow-query: 
+        - any
+      allow-transfer: 
+        - my_net
+      allow-update: 'none'
+      also-notify:
+        - 1.2.3.4
+        - 1.2.3.3
+      zone-statistics: yes                           # Enable detailed statistics for zone. You need enable statistics first
+
+    test.zone.com:
+      file: test.zone.com
+      type: slave
+      notify: False
+      masters:
+        - my_dns_masters                             # You can specify masters by using name 
+
+    test.zone2.com:                                  # Zone definied in default style of this formula
+      type: slave                                    # You need specify all info inside available_zones 
+      notify: False
+
+
+  configured_masters:                                # Configure master dns 
+    my_dns_masters:
+      - 10.10.20.20
+      - 10.10.30.30
+
+
+  available_zones:                                   # Configuration required in default style
+    test.zone2.com:
+      file: test.zone2.com                           # You are required specify file name here
+      masters:                                       # As also masters if you have slave type zone
+        - 10.167.73.21
+        - 10.174.60.44
+
+# End Debian based systems features 
 
 
 ### Keys, Zones, ACLs and Views             ###

--- a/pillar.example
+++ b/pillar.example
@@ -55,6 +55,160 @@ bind:
       versions: 5                                 # Additionaly you can set how many files will be stored
       size: '100m'                                # Maximum size of a individual file 
 
+    use_extensive_logging:                        # Enable extensive config for logging. 
+      channel:                                    # https://kb.isc.org/article/AA-01526/0/BIND-Logging-some-basic-recommendations.html
+        default_log:
+          file: default                           
+          size: '200m'                            # size of a individual file (default 20m)
+          versions: '10'                          # how many files will be stored (default 3)
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        auth_servers_log:
+          file: auth_servers
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        dnssec_log:
+          file: dnssec
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        zone_transfers_log:
+          file: zone_transfers
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        ddns_log:
+          file: ddns
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        client_security_log:
+          file: client_security
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        rate_limiting_log:
+          file: rate_limiting
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        rpz_log:
+          file: rpz
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        queries_log:
+          file: queries
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: info
+        query-errors_log:
+          file: query-errors
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          severity: dynamic
+        default_syslog:
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          syslog: daemon
+          severity: info
+        default_debug:
+          file: named.run
+          print-time: yes
+          print-category: yes
+          print-severity: yes
+          syslog: dynamic
+          severity: info
+      category:
+        default:
+          - default_syslog
+          - default_debug
+          - default_log
+        config:
+          - default_syslog
+          - default_debug
+          - default_log
+        dispatch:
+          - default_syslog
+          - default_debug
+          - default_log
+        network:
+          - default_syslog
+          - default_debug
+          - default_log
+        general:
+          - default_syslog
+          - default_debug
+          - default_log
+        resolver:
+          - auth_servers_log
+          - default_debug
+        cname:
+          - auth_servers_log
+          - default_debug
+        delegation-only:
+          - auth_servers_log
+          - default_debug
+        lame-servers:
+          - auth_servers_log
+          - default_debug
+        edns-disabled:
+          - auth_servers_log
+          - default_debug
+        dnssec:
+          - dnssec_log
+          - default_debug
+        notify:
+          - zone_transfers_log
+          - default_debug
+        xfer-in:
+          - zone_transfers_log
+          - default_debug
+        xfer-out:
+          - zone_transfers_log
+          - default_debug
+        update:
+          - ddns_log
+          - default_debug
+        update-security:
+          - ddns_log
+          - default_debug
+        client:
+          - client_security_log
+          - default_debug
+        security:
+          - client_security_log
+          - default_debug
+        rate-limit:
+          - rate_limiting_log
+          - default_debug
+        spill:
+          - rate_limiting_log
+          - default_debug
+        database:
+          - rate_limiting_log
+          - default_debug
+        rpz:
+          - rpz_log
+          - default_debug
+        queries:
+          - queries_log
+        query-errors:
+          - query-errors_log
+
   controls:
     local:
       enabled: true

--- a/pillar.example
+++ b/pillar.example
@@ -130,7 +130,6 @@ bind:
           print-time: yes
           print-category: yes
           print-severity: yes
-          syslog: dynamic
           severity: info
       category:
         default:
@@ -209,8 +208,22 @@ bind:
         query-errors:
           - query-errors_log
 
-  controls:
-    local:
+  rndc_client:                                       # Generate rndc.conf file it uses previously defined keys
+    options:                                         
+      default:
+        server: localhost
+        port: 953
+        key: my_default_key
+    server:
+      '127.0.0.1':
+        key: dns_key
+      'localhost':
+        key: dns_key
+      '8.8.8.8':
+        key: my_default_key
+
+  controls:                                          # If you define controls then you also should configure rndc_client
+    local:                                           
       enabled: true
       bind:
         address: 127.0.0.1

--- a/pillar.example
+++ b/pillar.example
@@ -49,60 +49,13 @@ bind:
     options:
       querylog: 'yes'                             # Enable query logs, by default is disabled in map.jinja (yes,no)
 
-    #use_extensive_logging: True                   # Enable extensive config for logging
 
-    use_extensive_logging:                        # Enable extensive config for logging                       
-      versions: 5                                 # Additionaly you can set how many files will be stored
-      size: '100m'                                # Maximum size of a individual file 
-
-    use_extensive_logging:                        # Enable extensive config for logging. 
+    use_extensive_logging:                        # Enable extensive config for logging. Partial example. For proposed settings please refer to
       channel:                                    # https://kb.isc.org/article/AA-01526/0/BIND-Logging-some-basic-recommendations.html
         default_log:
           file: default                           
           size: '200m'                            # size of a individual file (default 20m)
           versions: '10'                          # how many files will be stored (default 3)
-          print-time: yes
-          print-category: yes
-          print-severity: yes
-          severity: info
-        auth_servers_log:
-          file: auth_servers
-          print-time: yes
-          print-category: yes
-          print-severity: yes
-          severity: info
-        dnssec_log:
-          file: dnssec
-          print-time: yes
-          print-category: yes
-          print-severity: yes
-          severity: info
-        zone_transfers_log:
-          file: zone_transfers
-          print-time: yes
-          print-category: yes
-          print-severity: yes
-          severity: info
-        ddns_log:
-          file: ddns
-          print-time: yes
-          print-category: yes
-          print-severity: yes
-          severity: info
-        client_security_log:
-          file: client_security
-          print-time: yes
-          print-category: yes
-          print-severity: yes
-          severity: info
-        rate_limiting_log:
-          file: rate_limiting
-          print-time: yes
-          print-category: yes
-          print-severity: yes
-          severity: info
-        rpz_log:
-          file: rpz
           print-time: yes
           print-category: yes
           print-severity: yes
@@ -140,10 +93,6 @@ bind:
           - default_syslog
           - default_debug
           - default_log
-        dispatch:
-          - default_syslog
-          - default_debug
-          - default_log
         network:
           - default_syslog
           - default_debug
@@ -152,57 +101,6 @@ bind:
           - default_syslog
           - default_debug
           - default_log
-        resolver:
-          - auth_servers_log
-          - default_debug
-        cname:
-          - auth_servers_log
-          - default_debug
-        delegation-only:
-          - auth_servers_log
-          - default_debug
-        lame-servers:
-          - auth_servers_log
-          - default_debug
-        edns-disabled:
-          - auth_servers_log
-          - default_debug
-        dnssec:
-          - dnssec_log
-          - default_debug
-        notify:
-          - zone_transfers_log
-          - default_debug
-        xfer-in:
-          - zone_transfers_log
-          - default_debug
-        xfer-out:
-          - zone_transfers_log
-          - default_debug
-        update:
-          - ddns_log
-          - default_debug
-        update-security:
-          - ddns_log
-          - default_debug
-        client:
-          - client_security_log
-          - default_debug
-        security:
-          - client_security_log
-          - default_debug
-        rate-limit:
-          - rate_limiting_log
-          - default_debug
-        spill:
-          - rate_limiting_log
-          - default_debug
-        database:
-          - rate_limiting_log
-          - default_debug
-        rpz:
-          - rpz_log
-          - default_debug
         queries:
           - queries_log
         query-errors:
@@ -263,7 +161,7 @@ bind:
 
   configured_zones:                                  # Debian based systems can have zones using only configured_zones
     sub.domain.com:                                  # This zone will be copied from zones_source_dir
-      file: sub.domain.com                           # You can optionally specify name fd a file for the zone here. 
+      file: sub.domain.com                           # You can optionally specify name of a file here. 
       type: master                                   # Yo don't have define zone again in available_zones. 
                                                      # This feature is backward compatibile and only available in debian
       notify: False                                  # if type master you need specify notify True/False


### PR DESCRIPTION
Hello 
I just wanted to use this formula in my bind installation which is practically debian/ubuntu based. 

To be able use it I needed add some functionality that I hope will be useful to the community. 

Added: 
- optional extensible logging that is split to multiple channel and files.
- Zone can be configured by only using configured zones. File name and master servers are first are checked here, if missing as for now they are assigned from available_zones. This is done only for simple bind config without using views. 
- We can configure acl for master servers. We can use then one name in multiple zones and manage ip in one place.
- You can configure statistics. Useful for monitoring purposes. Eg for diamond: https://github.com/ppieprzycki/diamond_collectors/tree/master/bindxml
- Add controls option for remote management purposes. 
- added for zones  allow-query and zone-statistics options 


Changed/Fixed:
- Disabled logging queries by default. On heavily used dns servers logs can be significant in size (especially server under ddos)
- TTL value in zone file was always commented due to jinja formatting
- added example for new features in the pillar.example