### PR TITLE
Missing  rndc.conf file

### DIFF
--- a/bind/files/debian/rndc.conf
+++ b/bind/files/debian/rndc.conf
@@ -1,0 +1,22 @@
+options {
+        default-key "{{salt['pillar.get']('bind:rndc_client:options:default:key', 'rndc_key') }}";
+        default-server "{{salt['pillar.get']('bind:rndc_client:options:default:server', 'localhost') }}";
+        default-port {{salt['pillar.get']('bind:rndc_client:options:default:port', '953') }};
+};
+
+
+server sdns-odc-1.net.onet { key rndc_sdns-odc-1.net.onet; };
+
+
+{% for key,args in salt['pillar.get']('bind:rndc_client:server', {}).items()  -%}
+server "{{ key }}" {
+  key {{ args['key'] }};
+};
+{% endfor %}
+
+{% for key,args in salt['pillar.get']('bind:keys', {}).items()  -%}
+key "{{ key }}" {
+  algorithm {{ args['algorithm'] | default('HMAC-MD5.SIG-ALG.REG.INT') }};
+  secret "{{ args['secret'] }}";
+};
+{% endfor %}

--- a/bind/files/debian/rndc.conf
+++ b/bind/files/debian/rndc.conf
@@ -5,9 +5,6 @@ options {
 };
 
 
-server sdns-odc-1.net.onet { key rndc_sdns-odc-1.net.onet; };
-
-
 {% for key,args in salt['pillar.get']('bind:rndc_client:server', {}).items()  -%}
 server "{{ key }}" {
   key {{ args['key'] }};


### PR DESCRIPTION
Hi again
I've forgot in last PR add rndc.conf template file https://github.com/saltstack-formulas/bind-formula/pull/81

This template enable user to configure rndc client. It's useful when configure control channels with specific key. 

Sorry for that 