### PR TITLE
Manage mode, user and group and fix su in logrotate file

### DIFF
--- a/bind/files/debian/logrotate_bind
+++ b/bind/files/debian/logrotate_bind
@@ -1,6 +1,7 @@
 {%- from "bind/map.jinja" import map with context %}
 {%- set user = salt['pillar.get']('bind:config:user', map.user) %}
 {%- set group = salt['pillar.get']('bind:config:group', map.group) %}
+{%- set mode = salt['pillar.get']('bind:config:log_mode', map.log_mode) %}
 {{ map.log_dir }}/query.log {
     rotate 7
     daily
@@ -9,7 +10,7 @@
     sharedscripts
     copytruncate
     compress
-    create 0664 {{ user }} {{ group }}
+    create {{ mode }} {{ user }} {{ group }}
     {% if not salt['pkg.version']('logrotate').startswith('3.7')-%}
     su {{ user }} {{ group }}
     {% endif %}

--- a/bind/files/debian/logrotate_bind
+++ b/bind/files/debian/logrotate_bind
@@ -1,3 +1,6 @@
+{%- from "bind/map.jinja" import map with context %}
+{%- set user = salt['pillar.get']('bind:config:user', map.user) %}
+{%- set group = salt['pillar.get']('bind:config:group', map.group) %}
 {{ map.log_dir }}/query.log {
     rotate 7
     daily
@@ -6,8 +9,8 @@
     sharedscripts
     copytruncate
     compress
-    create 0664 bind root
+    create 0664 {{ user }} {{ group }}
     {% if not salt['pkg.version']('logrotate').startswith('3.7')-%}
-    su
+    su {{ user }} {{ group }}
     {% endif %}
 }


### PR DESCRIPTION
if I use this logrotate file I get this error:
`error: error switching euid to -1 and egid to -1: Das Argument ist ungültig`
I found, that "su" in logrotate need the user and group to switch to

The querry.log file is created by this formula and set the file mode, user and group based on pillar or map file. I think logrotate should keep this settings.

I tested this file it with
debian 9 (logrotate 3.11.0)
debian 8 (logrotate 3.8.7)
debian 7 (logrotate 3.8.1)