### PR TITLE
FreeBSD: bind99 will be deprecated soon

### DIFF
--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -60,7 +60,7 @@
         'mode': '640'
     },
     'FreeBSD': {
-        'pkgs': ['bind99'],
+        'pkgs': ['bind912'],
         'service': 'named',
         'config_source_dir': 'bind/files/freebsd',
         'zones_source_dir': 'zones',

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -60,7 +60,7 @@
         'mode': '640'
     },
     'FreeBSD': {
-        'pkgs': ['bind912'],
+        'pkgs': ['bind911'],
         'service': 'named',
         'config_source_dir': 'bind/files/freebsd',
         'zones_source_dir': 'zones',


### PR DESCRIPTION
https://www.freshports.org/dns/bind99/:
Going out of support, please migrate to dns/bind911

Replaced `bind99` with `bind912`.