### PR TITLE
Redhat/CentOS is broken by SELinux

### DIFF
--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -38,7 +38,7 @@
         'default_config': '/etc/sysconfig/named',
         'named_directory': '/var/named',
         'chroot_dir': '',
-        'log_dir': '/var/log/named',
+        'log_dir': '/var/named/data',
         'log_mode': '640',
         'user': 'named',
         'group': 'named',

--- a/test/integration/default/config_spec.rb
+++ b/test/integration/default/config_spec.rb
@@ -24,12 +24,17 @@ when 'arch','redhat', 'centos', 'fedora'
   named_directory = '/var/named'
   zones_directory = named_directory
   keys_directory  = '/etc/named.keys'
-  log_directory   = '/var/log/named'
   keys_mode       = '0755'
   conf_mode       = '0640'
   config          = '/etc/named.conf'
-when 'ubuntu'
+end
+
+# Override log directory by OS
+case os[:name]
+when 'arch', 'ubuntu'
   log_directory   = '/var/log/named'
+when 'redhat', 'centos', 'fedora'
+  log_directory   = '/var/named/data'
 end
 
 # Check main config dir

--- a/test/integration/default/zones_spec.rb
+++ b/test/integration/default/zones_spec.rb
@@ -24,12 +24,17 @@ when 'arch','redhat', 'centos', 'fedora'
   named_directory = '/var/named'
   zones_directory = named_directory
   keys_directory  = '/etc/named.keys'
-  log_directory   = '/var/log/named'
   keys_mode       = '0755'
   conf_mode       = '0640'
   config          = '/etc/named.conf'
-when 'ubuntu'
+end
+
+# Override log directory by OS
+case os[:name]
+when 'arch', 'ubuntu'
   log_directory   = '/var/log/named'
+when 'redhat', 'centos', 'fedora'
+  log_directory   = '/var/named/data'
 end
 
 # Test example.com zonefile
@@ -153,4 +158,3 @@ control 'File ' + zones_directory + '/100.51.198.in-addr.arpa.include' do
     its('content') { should match '7.100.51.198.in-addr.arpa. PTR mx1.example.net.' }
   end
 end
-


### PR DESCRIPTION
On CentOS/RHEL7 SELinux doesn't have permissions for the log file location selected. RHEL/CentOS default logging location for named is /var/named/data (in the original named.conf supplied in the RHEL/CentOS packaging)

`type=AVC msg=audit(1535031676.458:4738): avc:  denied  { open } for  pid=33274 comm="named" path="/var/log/named/query.log" dev="dm-3" ino=262174 scontext=system_u:system_r:named_t:s0 tcontext=system_u:object_r:var_log_t:s0 tclass=file`

As logging is enabled by default the standard state is broken for CentOS7 and RHEL7 when SELinux is enforcing.

This fixes #107