### PR TITLE
db.root is now outdated

### DIFF
--- a/bind/files/debian/named.conf.default-zones
+++ b/bind/files/debian/named.conf.default-zones
@@ -1,7 +1,7 @@
 // prime the server with knowledge of the root servers
 zone "." {
 	type hint;
-	file "/etc/bind/db.root";
+	file "/usr/share/dns/root.hints";
 };
 
 // be authoritative for the localhost forward and reverse zones, and for

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -1,6 +1,6 @@
 {% set map = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['bind9', 'bind9utils'],
+        'pkgs': ['bind9', 'bind9utils', 'dns-root-data'],
         'service': 'bind9',
         'config_source_dir': 'bind/files/debian',
         'zones_source_dir': 'zones',


### PR DESCRIPTION
Hello,

`db.root` has been deprecied and should not be used anymore, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=908191.

Thanks.