### PR TITLE
Update link to example in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Example Pillar
             type: master
             notify: False
 
-See *bind/pillar.example* for a more complete example.
+See *pillar.example* for a more complete example.
 
 Management of zone files
 ========================


### PR DESCRIPTION
pillar.example seems to have been moved to the root of the repository. Tried to make it a link but that only seems to work in Markdown, not in RST 🤷‍♂️