### PR TITLE
FreeBSD: support extensive logging

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -115,6 +115,23 @@ bind_default_config:
       - service: bind_restart
 {% endif %}
 
+{%- if salt['pillar.get']('bind:config:use_extensive_logging', False) %}
+bind_logging_config:
+  file.managed:
+    - name: {{ map.logging_config }}
+    - source: salt://bind/files/named.conf.logging.jinja
+    - template: jinja
+    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
+    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
+    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
+    - context:
+        map: {{ map }}
+    - require:
+      - pkg: bind
+    - watch_in:
+      - service: bind
+{%- endif %}
+
 {% if grains['os_family'] == 'Debian' %}
 bind_key_config:
   file.managed:
@@ -168,22 +185,6 @@ bind_default_zones:
     - context:
         map: {{ map }}
 
-{%- if salt['pillar.get']('bind:config:use_extensive_logging', False) %}
-bind_logging_config:
-  file.managed:
-    - name: {{ map.logging_config }}
-    - source: salt://bind/files/named.conf.logging.jinja
-    - template: jinja
-    - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
-    - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
-    - mode: {{ salt['pillar.get']('bind:config:mode', '644') }}
-    - context:
-        map: {{ map }}
-    - require:
-      - pkg: bind
-    - watch_in:
-      - service: bind
-{%- endif %}
 {%- if salt['pillar.get']('bind:rndc_client', False) %}
 bind_rndc_client_config:
   file.managed:

--- a/bind/map.jinja
+++ b/bind/map.jinja
@@ -82,6 +82,7 @@
         'zones_source_dir': 'zones',
         'config': '/usr/local/etc/namedb/named.conf',
         'local_config': '/usr/local/etc/namedb/named.conf.local',
+        'logging_config': '/usr/local/etc/namedb/named.conf.logging',
         'named_directory': '/usr/local/etc/namedb/working',
         'chroot_dir': '',
         'log_dir': '/var/log/named',


### PR DESCRIPTION
Just add the logging config file when extensive logging shall be used.

Tested on

- FreeBSD 11.2
- Debian 9.5