### PR TITLE
Fix configured_zones behaviour

### DIFF
--- a/pillar-with-views.example
+++ b/pillar-with-views.example
@@ -3,7 +3,7 @@ bind:
     internal:                                     # private IP range.
       - 10.0.0.0/8                                # In this case, an ACL for external isn't needed
                                                   # as that view will be matched by 'any'.
-   
+
   # Notice that there is no 'configured_zones' at this indentation level.
   # That is because when you are using views, the bind service forces all zones to be served via a view.
   #
@@ -11,7 +11,7 @@ bind:
   # also served via a view using a file include. If you have other zones being served outside of a view, bind will
   # fail to start and give you an error message indicating this. You will likely find these externally-defined zones
   # in /etc/named.conf and /etc/named.conf.local
-  
+
   configured_views:
     external:                                     # A view called 'external' to match anything except the 'internal' ACL.
       match_clients:
@@ -43,7 +43,7 @@ bind:
     external.mydomain.com:                        # Beginning of the 'external' zone definition.
       file: external.mydomain.com.txt             # The file in which to save this zone's record set - matches the file
                                                   # specified in the 'external' view.
-                                                  
+
       soa:                                        # Declare the SOA RRs for the zone
         ns: ns1.external.mydomain.com             # Required
         contact: hostmaster@mydomain.com          # Required
@@ -67,11 +67,11 @@ bind:
         CNAME:
           login: portal.mydomain.com.
           dashboard: www.mydomain.com.
-          
+
     internal.mydomain.com:                        # Beginning of the 'internal' zone definition.
       file: internal.mydomain.com.txt             # The file in which to save this zone's record set - matches the file
                                                   # specified in the 'internal' view.
-                                                  
+
       soa:                                        # Declare the SOA RRs for the zone
         ns: ns1.mydomain.com                      # Required
         contact: hostmaster@mydomain.com          # Required

--- a/pillar.example
+++ b/pillar.example
@@ -168,7 +168,7 @@ bind:
     sub.domain.com:                                  # This zone will be copied from zones_source_dir
       file: sub.domain.com                           # You can optionally specify name of a file here. 
       type: master                                   # Yo don't have define zone again in available_zones. 
-                                                     # This feature is backward compatibile and only available in debian
+                                                     # This feature is backward compatible and only available in debian
       notify: False                                  # if type master you need specify notify True/False
 
     sub2.domain.com:                                 

--- a/pillar.example
+++ b/pillar.example
@@ -290,7 +290,7 @@ bind:
                                                   # serve a different record set in each.
                                                   # If doing this, you need to configure the zones and their record sets
                                                   # underneath the 'available_zones' section.
-          notify: False    
+          notify: False
           update_policy:                          # A given update policy
             - "grant core_dhcp name dns_entry_allowed_to_update. ANY"
 


### PR DESCRIPTION
Hello,

With the latest commits, we unconditionally perform a *file.managed* state because the *file* argument is always defined. I think that it breaks the previous *configured_zones* behaviour, as we may want to declare a zone (and *bind* has to know the filename) without managing it.

Feel free to comment.