### PR TITLE
fix: corrected indentation on context in file.managed states

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -229,10 +229,10 @@ zones{{ dash_view }}-{{ zone }}{{ '.include' if serial_auto else ''}}:
     - template: jinja
     {% if zone_records != {} %}
     - context:
-      zone: zones{{ dash_view }}-{{ zone }}
-      soa: {{ salt['pillar.get']("bind:available_zones:" + zone + ":soa") | json }}
-      records: {{ zone_records | json }}
-      include: False
+        zone: zones{{ dash_view }}-{{ zone }}
+        soa: {{ salt['pillar.get']("bind:available_zones:" + zone + ":soa") | json }}
+        records: {{ zone_records | json }}
+        include: False
     {% endif %}
     - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
     - group: {{ salt['pillar.get']('bind:config:group', map.group) }}
@@ -261,9 +261,9 @@ zones{{ dash_view }}-{{ zone }}:
     - template: jinja
     {% if zone_records != {} %}
     - context:
-      zone: zones{{ dash_view }}-{{ zone }}
-      soa: {{ salt['pillar.get']("bind:available_zones:" + zone + ":soa") | json }}
-      include: {{ zones_directory }}/{{ file }}.include
+        zone: zones{{ dash_view }}-{{ zone }}
+        soa: {{ salt['pillar.get']("bind:available_zones:" + zone + ":soa") | json }}
+        include: {{ zones_directory }}/{{ file }}.include
     {% endif %}
     - user: {{ salt['pillar.get']('bind:config:user', map.user) }}
     - group: {{ salt['pillar.get']('bind:config:group', map.group) }}


### PR DESCRIPTION
When indentation in `context` is wrong, it can lead to errors, see https://github.com/daks/saltbug-formula for an example.