### PR TITLE
Disable query logging default

### DIFF
--- a/bind/files/named.conf.local.jinja
+++ b/bind/files/named.conf.local.jinja
@@ -132,10 +132,9 @@ view {{ view }} {
 };
 {%- endfor %}
 
-{%- if salt['pillar.get']('bind:config:enable_logging', True) %}
 {%- if salt['pillar.get']('bind:config:use_extensive_logging', False) %}
 include "{{ map.logging_config }}";
-{% else %}
+{% elif salt['pillar.get']('bind:config:enable_logging', False) %}
 logging {
   channel "querylog" {
     file "{{ map.log_dir }}/query.log";
@@ -143,7 +142,6 @@ logging {
   };
   category queries { querylog; };
 };
-{%- endif %}
 {%- endif %}
 
 {%- if salt['pillar.get']('bind:controls', False) %}

--- a/pillar.example
+++ b/pillar.example
@@ -28,10 +28,10 @@ bind:
     user: root                                    # File & Directory user
     group: named                                  # File & Directory group
     mode: 640                                     # File & Directory mode
-    enable_logging: true                          # Enable basic query logging
-    use_extensive_logging:                        # Enable extensive config for logging. Partial example. For proposed settings please refer to
-      channel:                                    # https://kb.isc.org/article/AA-01526/0/BIND-Logging-some-basic-recommendations.html
-        default_log:
+    enable_logging: true                          # Enable basic query logging in $log_dir/query.log
+    use_extensive_logging:                        # Alternatively, enable much more extensive config for logging.
+      channel:                                    # Partial example. For proposed settings please refer to
+        default_log:                              # https://kb.isc.org/article/AA-01526/0/BIND-Logging-some-basic-recommendations.html
           file: default                           
           size: '200m'                            # size of a individual file (default 20m)
           versions: '10'                          # how many files will be stored (default 3)


### PR DESCRIPTION
By default, the bind formula will configure the named process to
write all queries into a query.log file which potentially is outside
the normal log-rotated dirs, thus filling up the disk.

This is rather unexpected on high traffic DNS servers.

Disable by default, can be explicity reenabled by setting enable_logging
to True.

Rework jinja logic to make enable_logging and use_extensive_logging mutually
exclusive rather than having them "stacked". It makes no sense to have the
fine-grained use_extensive_logging configuration depend on the coarse-grained
enable_logging toggle.

I am actually tempted to rename enable_logging to enable_query_log which is a
much clearer description of the functionality. Comments?
Somewhat related, log_dir is /var/log/something for every OS except Red Hat
where it is defined as /var/named/data... Any reason not to fix that
inconsistency other than the use of the chrooted functionality on Red Hat?