### PR TITLE
ci(kitchen+travis): modify matrix to include `develop` platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,30 @@ services:
 # the `platforms` defined in `kitchen.yml`
 env:
   matrix:
-    - INSTANCE: default-debian-9-2019-2-py3
-    #- INSTANCE: default-ubuntu-1804-2019-2-py3
+    - INSTANCE: default-debian-9-develop-py3
+    # - INSTANCE: default-ubuntu-1804-develop-py3
+    # - INSTANCE: default-centos-7-develop-py3
+    # - INSTANCE: default-fedora-29-develop-py3
+    # - INSTANCE: default-opensuse-leap-15-develop-py3
+    # - INSTANCE: default-debian-9-2019-2-py3
+    - INSTANCE: default-ubuntu-1804-2019-2-py3
     - INSTANCE: default-centos-7-2019-2-py3
-    #- INSTANCE: default-fedora-29-2019-2-py3
-    - INSTANCE: default-opensuse-leap-15-2019-2-py3
-    #- INSTANCE: default-debian-9-2018-3-py2
-    - INSTANCE: default-ubuntu-1604-2018-3-py2
-    #- INSTANCE: default-centos-7-2018-3-py2
-    #- INSTANCE: default-fedora-29-2018-3-py2
+    # - INSTANCE: default-fedora-29-2019-2-py3
+    # - INSTANCE: default-opensuse-leap-15-2019-2-py3
+    # - INSTANCE: default-debian-9-2018-3-py2
+    # - INSTANCE: default-ubuntu-1604-2018-3-py2
+    # - INSTANCE: default-centos-7-2018-3-py2
+    # - INSTANCE: default-fedora-29-2018-3-py2
     # TODO: Use this when fixed instead of `opensuse-leap-42`
     # Ref: https://github.com/netmanagers/salt-image-builder/issues/2
     # - INSTANCE: default-opensuse-leap-15-2018-3-py2
-    #- INSTANCE: default-opensuse-leap-42-2018-3-py2
-    #- INSTANCE: default-debian-8-2017-7-py2
-    #- INSTANCE: default-ubuntu-1604-2017-7-py2
-#    # TODO: Enable after improving the formula to work with other than `systemd`
-#    - INSTANCE: default-centos-6-2017-7-py2
-    #- INSTANCE: default-fedora-28-2017-7-py2
-    #- INSTANCE: default-opensuse-leap-42-2017-7-py2
+    - INSTANCE: default-opensuse-leap-42-2018-3-py2
+    # - INSTANCE: default-debian-8-2017-7-py2
+    # - INSTANCE: default-ubuntu-1604-2017-7-py2
+    # TODO: Enable after improving the formula to work with other than `systemd`
+    - INSTANCE: default-centos-6-2017-7-py2
+    # - INSTANCE: default-fedora-28-2017-7-py2
+    # - INSTANCE: default-opensuse-leap-42-2017-7-py2
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source "https://rubygems.org"
 gem 'kitchen-docker', '>= 2.9'
 gem 'kitchen-salt', '>= 0.6.0'
 gem 'kitchen-inspec', '>= 1.1'
-gem 'train', git: 'https://github.com/n-rodriguez/train.git', branch: 'wip/fix_suse'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,6 +11,39 @@ driver:
 # Make sure the platforms listed below match up with
 # the `env.matrix` instances defined in `.travis.yml`
 platforms:
+  ## SALT `develop`
+  - name: debian-9-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:debian-9
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: ubuntu-1804-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:ubuntu-18.04
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: centos-7-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:centos-7
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: fedora-29-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:fedora-29
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: opensuse-leap-15-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:opensuse-leap-15
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+      run_command: /usr/lib/systemd/systemd
+
   ## SALT 2019.2
   - name: debian-9-2019-2-py3
     driver:


### PR DESCRIPTION
* Use balanced matrix based on `template-formula` guidelines
* Initial ref: https://github.com/saltstack-formulas/template-formula/issues/118
* Fedora still disabled (ref: #129)
* Remove temporary `train` Gem (CC: @n-rodriguez)