### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/default.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  comments-indentation:
+    ignore: |
+      pillar.example
+  key-duplicates:
+    ignore: |
+      pillar.example
+  line-length:
+    ignore: |
+      pillar.example
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # Note - Each section beginning with 'bind:' below represents a different way you may configure
-         pillars for bind. When configuring your pillar(s), you may use any combination of subsections,
-         but salt will not merge sections with the same heading.
+#        pillars for bind. When configuring your pillar(s), you may use any combination of subsections,
+#        but salt will not merge sections with the same heading.
 
 
 ### Overrides for the defaults specified by ###
@@ -32,36 +35,36 @@ bind:
     use_extensive_logging:                        # Enable extensive config for logging. Partial example. For proposed settings please refer to
       channel:                                    # https://kb.isc.org/article/AA-01526/0/BIND-Logging-some-basic-recommendations.html
         default_log:
-          file: default                           
+          file: default
           size: '200m'                            # size of a individual file (default 20m)
           versions: '10'                          # how many files will be stored (default 3)
-          print-time: yes
-          print-category: yes
-          print-severity: yes
+          print-time: true
+          print-category: true
+          print-severity: true
           severity: info
         queries_log:
           file: queries
-          print-time: yes
-          print-category: yes
-          print-severity: yes
+          print-time: true
+          print-category: true
+          print-severity: true
           severity: info
         query-errors_log:
           file: query-errors
-          print-time: yes
-          print-category: yes
-          print-severity: yes
+          print-time: true
+          print-category: true
+          print-severity: true
           severity: dynamic
         default_syslog:
-          print-time: yes
-          print-category: yes
-          print-severity: yes
+          print-time: true
+          print-category: true
+          print-severity: true
           syslog: daemon
           severity: info
         default_debug:
           file: named.run
-          print-time: yes
-          print-category: yes
-          print-severity: yes
+          print-time: true
+          print-category: true
+          print-severity: true
           severity: info
       category:
         default:
@@ -99,21 +102,21 @@ bind:
                                                   # (ipv4: 4, ipv6: 6). Omitting this reverts to
                                                   # binds default of both.
 
-# Debian and FreeBSD based systems 
-    default_zones: True                           # If set to True, the default-zones configuration
-                                                  # will be enabled. Defaults to False.
+# Debian and FreeBSD based systems
+    default_zones: true                           # If set to true, the default-zones configuration
+                                                  # will be enabled. Defaults to false.
 
     includes:                                     # Include any additional configuration file(s) in
       - /some/additional/named.conf               # named.conf
 
-# Debian based systems optional configs 
+# Debian based systems optional configs
 bind:
   config:
     options:
       querylog: 'yes'                             # Enable query logs, by default is disabled in map.jinja (yes,no)
 
   rndc_client:                                       # Generate rndc.conf file it uses previously defined keys
-    options:                                         
+    options:
       default:
         server: localhost
         port: 953
@@ -127,7 +130,7 @@ bind:
         key: my_default_key
 
   controls:                                          # If you define controls then you also should configure rndc_client
-    local:                                           
+    local:
       enabled: true
       bind:
         address: 127.0.0.1
@@ -147,7 +150,7 @@ bind:
       keys:
         - core_dhcp
 
-  statistics:                                        # Enable statistics-channel 
+  statistics:                                        # Enable statistics-channel
     local:
       enabled: true
       bind:
@@ -166,38 +169,38 @@ bind:
 
   configured_zones:                                  # Debian based systems can have zones using only configured_zones
     sub.domain.com:                                  # This zone will be copied from zones_source_dir
-      file: sub.domain.com                           # You can optionally specify name of a file here. 
-      type: master                                   # Yo don't have define zone again in available_zones. 
+      file: sub.domain.com                           # You can optionally specify name of a file here.
+      type: master                                   # Yo don't have define zone again in available_zones.
                                                      # This feature is backward compatibile and only available in debian
-      notify: False                                  # if type master you need specify notify True/False
+      notify: false                                  # if type master you need specify notify true/false
 
-    sub2.domain.com:                                 
+    sub2.domain.com:
       file: sub2.domain.com
       type: master
-      notify: True
-      allow-query: 
+      notify: true
+      allow-query:
         - any
-      allow-transfer: 
+      allow-transfer:
         - my_net
       allow-update: 'none'
       also-notify:
         - 1.2.3.4
         - 1.2.3.3
-      zone-statistics: yes                           # Enable detailed statistics for zone. You need enable statistics first
+      zone-statistics: true                           # Enable detailed statistics for zone. You need enable statistics first
 
     test.zone.com:
       file: test.zone.com
       type: slave
-      notify: False
+      notify: false
       masters:
-        - my_dns_masters                             # You can specify masters by using name 
+        - my_dns_masters                             # You can specify masters by using name
 
     test.zone2.com:                                  # Zone definied in default style of this formula
-      type: slave                                    # You need specify all info inside available_zones 
-      notify: False
+      type: slave                                    # You need specify all info inside available_zones
+      notify: false
 
 
-  configured_masters:                                # Configure master dns 
+  configured_masters:                                # Configure master dns
     my_dns_masters:
       - 10.10.20.20
       - 10.10.30.30
@@ -210,13 +213,12 @@ bind:
         - 10.167.73.21
         - 10.174.60.44
 
-# End Debian based systems features 
+# End Debian based systems features
 
 # on SUSE include the forwarders.conf file generated by netconfig(8)
 bind:
   config:
-    include_forwarders: True
-
+    include_forwarders: true
 
 
 ### Keys, Zones, ACLs and Views             ###
@@ -228,7 +230,7 @@ bind:
   configured_zones:
     sub.domain.com:                               # First domain zone
       type: master                                # We're the master of this zone
-      notify: False                               # Don't notify any NS RRs of any changes to zone
+      notify: false                               # Don't notify any NS RRs of any changes to zone
       also-notify:                                # Do notify these IP addresses (pointless as
         - 1.1.1.1                                 # notify has been set to no)
         - 2.2.2.2                                 # If using views, do not define configured_zones
@@ -237,20 +239,20 @@ bind:
 
     sub.domain2.com:                              # Domain zone with DNSSEC
       type: master                                # We're the master of this zone
-      notify: False                               # Don't notify any NS RRs of any changes to zone
-      dnssec: True                                # Create and manage signed zonefile with zonesigner
+      notify: false                               # Don't notify any NS RRs of any changes to zone
+      dnssec: true                                # Create and manage signed zonefile with zonesigner
                                                   # You will have to install dnssec-tools by hand
                                                   # on many distributions
 
     sub.domain3.com:                              # Domain zone with DNSSEC
       type: master                                # We're the master of this zone
-      notify: False                               # Don't notify any NS RRs of any changes to zone
+      notify: false                               # Don't notify any NS RRs of any changes to zone
       auto-dnssec: 'maintain'                     # Bind will create and manage the signed zonefile
                                                   # itself, we only have to provide the clear zone
 
     1.168.192.in-addr.arpa:                       # Reverse lookup for local IPs
       type: master                                # As above
-      notify: False                               # As above
+      notify: false                               # As above
       allow-transfer:                             # As above
         - 1.1.1.1
         - 2.2.2.2
@@ -258,7 +260,7 @@ bind:
     dynamic.domain.com:                           # Our ddns zone
       type: master                                # As above
       allow-update: "key core_dhcp"               # Who we allow updates from (refers to above key)
-      notify: True                                # Notify NS RRs of changes
+      notify: true                                # Notify NS RRs of changes
 
     sub.anotherdomain.com:                        # Another domain zone
       type: forward                               # This time it's a forwarding zone
@@ -290,7 +292,7 @@ bind:
                                                   # serve a different record set in each.
                                                   # If doing this, you need to configure the zones and their record sets
                                                   # underneath the 'available_zones' section.
-          notify: False    
+          notify: false
           update_policy:                          # A given update policy
             - "grant core_dhcp name dns_entry_allowed_to_update. ANY"
 
@@ -339,8 +341,6 @@ bind:
             - '"some_value"'
             - '"v=spf1 mx a ip4:1.2.3.4 ~all"'
           _dmarc: '"v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com; fo=1:d:s; adkim=r; aspf=r; pct=100; ri=86400"'
-
-
 
 
     3.2.1.in-addr.arpa:                           # auto-generated reverse zone

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: bind formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 bind:
   configured_acls:
     client1:
@@ -8,15 +11,15 @@ bind:
   configured_zones:
     example.com:
       type: master
-      notify: False
+      notify: false
       update_policy:
         - "grant core_dhcp name dns_entry_allowed_to_update. ANY"
     example.net:
       type: master
-      notify: False
+      notify: false
     example.org:
       type: slave
-      notify: False
+      notify: false
       masters:
         - 192.0.2.1
         - 192.0.2.2
@@ -25,7 +28,7 @@ bind:
       notify: false
     100.51.198.in-addr.arpa:
       type: master
-      notify: False
+      notify: false
   available_zones:
     example.net:
       file: example.net
@@ -111,4 +114,3 @@ bind:
         net: 198.51.100.0/24
         for_zones:
           - example.net
-


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix (or ignore) errors shown below:

```bash
bind-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  1:1       warning  comment not indented like content  (comments-indentation)
  1:89      error    line too long (95 > 88 characters)  (line-length)
  2:1       warning  missing document start "---"  (document-start)
  2:10      error    wrong indentation: expected 0 but found 9  (indentation)
  2:89      error    line too long (103 > 88 characters)  (line-length)
  8:1       error    syntax error: expected '<document start>', but found '<block mapping start>'
  14:89     error    line too long (94 > 88 characters)  (line-length)
  15:51     warning  comment not indented like content  (comments-indentation)
  19:1      error    duplication of key "bind" in mapping  (key-duplicates)
  21:89     error    line too long (93 > 88 characters)  (line-length)
  23:89     error    line too long (102 > 88 characters)  (line-length)
  27:89     error    line too long (96 > 88 characters)  (line-length)
  32:89     error    line too long (143 > 88 characters)  (line-length)
  33:89     error    line too long (134 > 88 characters)  (line-length)
  35:24     error    trailing spaces  (trailing-spaces)
  36:89     error    line too long (91 > 88 characters)  (line-length)
  37:89     error    line too long (93 > 88 characters)  (line-length)
  38:23     warning  truthy value should be one of [false, true]  (truthy)
  39:27     warning  truthy value should be one of [false, true]  (truthy)
  40:27     warning  truthy value should be one of [false, true]  (truthy)
  44:23     warning  truthy value should be one of [false, true]  (truthy)
  45:27     warning  truthy value should be one of [false, true]  (truthy)
  46:27     warning  truthy value should be one of [false, true]  (truthy)
  50:23     warning  truthy value should be one of [false, true]  (truthy)
  51:27     warning  truthy value should be one of [false, true]  (truthy)
  52:27     warning  truthy value should be one of [false, true]  (truthy)
  55:23     warning  truthy value should be one of [false, true]  (truthy)
  56:27     warning  truthy value should be one of [false, true]  (truthy)
  57:27     warning  truthy value should be one of [false, true]  (truthy)
  62:23     warning  truthy value should be one of [false, true]  (truthy)
  63:27     warning  truthy value should be one of [false, true]  (truthy)
  64:27     warning  truthy value should be one of [false, true]  (truthy)
  89:89     error    line too long (91 > 88 characters)  (line-length)
  90:1      warning  comment not indented like content  (comments-indentation)
  97:1      warning  comment not indented like content  (comments-indentation)
  98:89     error    line too long (92 > 88 characters)  (line-length)
  99:51     warning  comment not indented like content  (comments-indentation)
  99:89     error    line too long (96 > 88 characters)  (line-length)
  102:1     warning  comment not indented like content  (comments-indentation)
  102:35    error    trailing spaces  (trailing-spaces)
  103:20    warning  truthy value should be one of [false, true]  (truthy)
  103:89    error    line too long (99 > 88 characters)  (line-length)
  104:51    warning  comment not indented like content  (comments-indentation)
  106:89    error    line too long (99 > 88 characters)  (line-length)
  109:40    error    trailing spaces  (trailing-spaces)
  110:1     error    duplication of key "bind" in mapping  (key-duplicates)
  113:89    error    line too long (115 > 88 characters)  (line-length)
  115:89    error    line too long (110 > 88 characters)  (line-length)
  116:13    error    trailing spaces  (trailing-spaces)
  129:89    error    line too long (120 > 88 characters)  (line-length)
  130:11    error    trailing spaces  (trailing-spaces)
  150:81    error    trailing spaces  (trailing-spaces)
  167:89    error    line too long (118 > 88 characters)  (line-length)
  168:89    error    line too long (101 > 88 characters)  (line-length)
  169:89    error    line too long (103 > 88 characters)  (line-length)
  169:103   error    trailing spaces  (trailing-spaces)
  170:89    error    line too long (107 > 88 characters)  (line-length)
  170:107   error    trailing spaces  (trailing-spaces)
  171:54    warning  comment not indented like content  (comments-indentation)
  171:89    error    line too long (120 > 88 characters)  (line-length)
  172:15    warning  truthy value should be one of [false, true]  (truthy)
  172:89    error    line too long (104 > 88 characters)  (line-length)
  174:21    error    trailing spaces  (trailing-spaces)
  177:15    warning  truthy value should be one of [false, true]  (truthy)
  178:19    error    trailing spaces  (trailing-spaces)
  180:22    error    trailing spaces  (trailing-spaces)
  186:24    warning  truthy value should be one of [false, true]  (truthy)
  186:89    error    line too long (124 > 88 characters)  (line-length)
  191:15    warning  truthy value should be one of [false, true]  (truthy)
  193:89    error    line too long (93 > 88 characters)  (line-length)
  193:93    error    trailing spaces  (trailing-spaces)
  195:89    error    line too long (101 > 88 characters)  (line-length)
  196:89    error    line too long (104 > 88 characters)  (line-length)
  196:104   error    trailing spaces  (trailing-spaces)
  197:15    warning  truthy value should be one of [false, true]  (truthy)
  200:76    error    trailing spaces  (trailing-spaces)
  206:89    error    line too long (94 > 88 characters)  (line-length)
  208:89    error    line too long (94 > 88 characters)  (line-length)
  209:89    error    line too long (98 > 88 characters)  (line-length)
  213:36    error    trailing spaces  (trailing-spaces)
  216:1     error    duplication of key "bind" in mapping  (key-duplicates)
  218:25    warning  truthy value should be one of [false, true]  (truthy)
  221:1     error    too many blank lines (3 > 2)  (empty-lines)
  223:1     error    duplication of key "bind" in mapping  (key-duplicates)
  231:15    warning  truthy value should be one of [false, true]  (truthy)
  231:89    error    line too long (98 > 88 characters)  (line-length)
  232:89    error    line too long (94 > 88 characters)  (line-length)
  234:89    error    line too long (98 > 88 characters)  (line-length)
  235:51    warning  comment not indented like content  (comments-indentation)
  235:89    error    line too long (107 > 88 characters)  (line-length)
  240:15    warning  truthy value should be one of [false, true]  (truthy)
  240:89    error    line too long (98 > 88 characters)  (line-length)
  241:15    warning  truthy value should be one of [false, true]  (truthy)
  241:89    error    line too long (101 > 88 characters)  (line-length)
  242:51    warning  comment not indented like content  (comments-indentation)
  242:89    error    line too long (97 > 88 characters)  (line-length)
  247:15    warning  truthy value should be one of [false, true]  (truthy)
  247:89    error    line too long (98 > 88 characters)  (line-length)
  248:89    error    line too long (99 > 88 characters)  (line-length)
  249:51    warning  comment not indented like content  (comments-indentation)
  249:89    error    line too long (98 > 88 characters)  (line-length)
  253:15    warning  truthy value should be one of [false, true]  (truthy)
  260:89    error    line too long (99 > 88 characters)  (line-length)
  261:15    warning  truthy value should be one of [false, true]  (truthy)
  271:89    error    line too long (96 > 88 characters)  (line-length)
  284:89    error    line too long (109 > 88 characters)  (line-length)
  285:51    warning  comment not indented like content  (comments-indentation)
  285:89    error    line too long (128 > 88 characters)  (line-length)
  286:89    error    line too long (114 > 88 characters)  (line-length)
  287:89    error    line too long (127 > 88 characters)  (line-length)
  289:89    error    line too long (122 > 88 characters)  (line-length)
  290:89    error    line too long (89 > 88 characters)  (line-length)
  291:89    error    line too long (120 > 88 characters)  (line-length)
  292:89    error    line too long (93 > 88 characters)  (line-length)
  293:19    warning  truthy value should be one of [false, true]  (truthy)
  293:24    error    trailing spaces  (trailing-spaces)
  300:89    error    line too long (119 > 88 characters)  (line-length)
  301:51    warning  comment not indented like content  (comments-indentation)
  301:89    error    line too long (122 > 88 characters)  (line-length)
  302:89    error    line too long (93 > 88 characters)  (line-length)
  305:1     error    duplication of key "bind" in mapping  (key-duplicates)
  313:1     warning  comment not indented like content  (comments-indentation)
  313:89    error    line too long (99 > 88 characters)  (line-length)
  320:89    error    line too long (89 > 88 characters)  (line-length)
  337:89    error    line too long (95 > 88 characters)  (line-length)
  341:89    error    line too long (120 > 88 characters)  (line-length)
  345:1     error    too many blank lines (4 > 2)  (empty-lines)
  358:89    error    line too long (89 > 88 characters)  (line-length)
  362:89    error    line too long (117 > 88 characters)  (line-length)
  363:89    error    line too long (89 > 88 characters)  (line-length)
  365:89    error    line too long (102 > 88 characters)  (line-length)
  371:1     error    duplication of key "bind" in mapping  (key-duplicates)

test/salt/pillar/default.sls
  1:1       warning  missing document start "---"  (document-start)
  11:15     warning  truthy value should be one of [false, true]  (truthy)
  16:15     warning  truthy value should be one of [false, true]  (truthy)
  19:15     warning  truthy value should be one of [false, true]  (truthy)
  28:15     warning  truthy value should be one of [false, true]  (truthy)
  114:1     error    too many blank lines (1 > 0)  (empty-lines)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.

Due to the sheer number of lint errors here, I've used a customised `.yamllint` file ignoring most of them:

```yaml
  comments-indentation:
    ignore: |
      pillar.example
  key-duplicates:
    ignore: |
      pillar.example
  line-length:
    ignore: |
      pillar.example
```

These can be resolved in a subsequent PR, once there's been a discussion about how to fix the situation appropriately.  With the ignores, the `yamllint` passes.