### PR TITLE
ci(yamllint): add rule `empty-values` & use new `yaml-files` setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ jobs:
       before_install: skip
       script:
         # Install and run `yamllint`
-        - pip install --user yamllint
-        # yamllint disable-line rule:line-length
-        - yamllint -s . .yamllint pillar.example test/salt/pillar/default.sls
+        # Need at least `v1.17.0` for the `yaml-files` setting
+        - pip install --user yamllint>=1.17.0
+        - yamllint -s .
         # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D

--- a/.yamllint
+++ b/.yamllint
@@ -6,19 +6,35 @@ extends: default
 
 # Files to ignore completely
 # 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+# 2. Any SLS files under directory `test/`, which are actually state files
 ignore: |
   node_modules/
+  test/**/states/**/*.sls
+
+yaml-files:
+  # Default settings
+  - '*.yaml'
+  - '*.yml'
+  - .yamllint
+  # SaltStack Formulas additional settings
+  - '*.example'
+  - test/**/*.sls
 
 rules:
   comments-indentation:
     ignore: |
       pillar.example
+      pillar-with-views.example
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
   key-duplicates:
     ignore: |
       pillar.example
   line-length:
     ignore: |
       pillar.example
+      pillar-with-views.example
     # Increase from default of `80`
     # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
     max: 88

--- a/pillar-with-views.example
+++ b/pillar-with-views.example
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 bind:
   configured_acls:                                # We have an internal ACL restricted to our
     internal:                                     # private IP range.
       - 10.0.0.0/8                                # In this case, an ACL for external isn't needed
                                                   # as that view will be matched by 'any'.
-   
+
   # Notice that there is no 'configured_zones' at this indentation level.
   # That is because when you are using views, the bind service forces all zones to be served via a view.
   #
@@ -11,7 +14,7 @@ bind:
   # also served via a view using a file include. If you have other zones being served outside of a view, bind will
   # fail to start and give you an error message indicating this. You will likely find these externally-defined zones
   # in /etc/named.conf and /etc/named.conf.local
-  
+
   configured_views:
     external:                                     # A view called 'external' to match anything except the 'internal' ACL.
       match_clients:
@@ -20,11 +23,11 @@ bind:
         mydomain.com:                             # Notice that this value matches on both views.
           type: master
           file: external.mydomain.com.txt         # Specify the file to be used, which must match the file
-          recursion: yes                          # name of the zone below under available_zones.
-                                                  # This filename also must match the corresponding zone name 
+          recursion: 'yes'                        # name of the zone below under available_zones.
+                                                  # This filename also must match the corresponding zone name
                                                   # without the .txt extension (and be sure to use .txt as the extension).
-          notify: False
-          dnssec: False
+          notify: false
+          dnssec: false
 
     internal:                                     # The 'internal' view that is restricted to the 'internal' ACL.
       match_clients:
@@ -33,17 +36,17 @@ bind:
         mydomain.com:                             # Same as above - both views will serve the same zone.
           type: master
           file: internal.mydomain.com.txt         # Different file - matches the internal zone below.
-                                                  # Again, this filename must match the corresponding zone name 
+                                                  # Again, this filename must match the corresponding zone name
                                                   # without the .txt extension (and be sure to use .txt as the extension).
-          recursion: yes
-          notify: False
-          dnssec: False
+          recursion: 'yes'
+          notify: false
+          dnssec: false
 
   available_zones:
     external.mydomain.com:                        # Beginning of the 'external' zone definition.
       file: external.mydomain.com.txt             # The file in which to save this zone's record set - matches the file
                                                   # specified in the 'external' view.
-                                                  
+
       soa:                                        # Declare the SOA RRs for the zone
         ns: ns1.external.mydomain.com             # Required
         contact: hostmaster@mydomain.com          # Required
@@ -67,11 +70,11 @@ bind:
         CNAME:
           login: portal.mydomain.com.
           dashboard: www.mydomain.com.
-          
+
     internal.mydomain.com:                        # Beginning of the 'internal' zone definition.
       file: internal.mydomain.com.txt             # The file in which to save this zone's record set - matches the file
                                                   # specified in the 'internal' view.
-                                                  
+
       soa:                                        # Declare the SOA RRs for the zone
         ns: ns1.mydomain.com                      # Required
         contact: hostmaster@mydomain.com          # Required


### PR DESCRIPTION
* Semi-automated using https://github.com/myii/ssf-formula/pull/27
* Fix errors shown below:

```bash
bind-formula$ yamllint -s .
./pillar-with-views.example
  1:1       warning  missing document start "---"  (document-start)
  2:89      error    line too long (93 > 88 characters)  (line-length)
  4:89      error    line too long (98 > 88 characters)  (line-length)
  5:51      warning  comment not indented like content  (comments-indentation)
  5:89      error    line too long (90 > 88 characters)  (line-length)
  6:1       error    trailing spaces  (trailing-spaces)
  8:89      error    line too long (104 > 88 characters)  (line-length)
  10:89     error    line too long (104 > 88 characters)  (line-length)
  11:89     error    line too long (114 > 88 characters)  (line-length)
  12:89     error    line too long (116 > 88 characters)  (line-length)
  14:1      error    trailing spaces  (trailing-spaces)
  16:89     error    line too long (121 > 88 characters)  (line-length)
  18:89     error    line too long (108 > 88 characters)  (line-length)
  20:89     error    line too long (97 > 88 characters)  (line-length)
  22:89     error    line too long (106 > 88 characters)  (line-length)
  23:22     warning  truthy value should be one of [false, true]  (truthy)
  23:89     error    line too long (97 > 88 characters)  (line-length)
  24:51     warning  comment not indented like content  (comments-indentation)
  24:89     error    line too long (110 > 88 characters)  (line-length)
  24:110    error    trailing spaces  (trailing-spaces)
  25:89     error    line too long (122 > 88 characters)  (line-length)
  26:19     warning  truthy value should be one of [false, true]  (truthy)
  27:19     warning  truthy value should be one of [false, true]  (truthy)
  29:89     error    line too long (113 > 88 characters)  (line-length)
  31:89     error    line too long (98 > 88 characters)  (line-length)
  33:89     error    line too long (104 > 88 characters)  (line-length)
  35:89     error    line too long (101 > 88 characters)  (line-length)
  36:51     warning  comment not indented like content  (comments-indentation)
  36:89     error    line too long (112 > 88 characters)  (line-length)
  36:112    error    trailing spaces  (trailing-spaces)
  37:89     error    line too long (122 > 88 characters)  (line-length)
  38:22     warning  truthy value should be one of [false, true]  (truthy)
  39:19     warning  truthy value should be one of [false, true]  (truthy)
  40:19     warning  truthy value should be one of [false, true]  (truthy)
  43:89     error    line too long (96 > 88 characters)  (line-length)
  44:89     error    line too long (119 > 88 characters)  (line-length)
  45:51     warning  comment not indented like content  (comments-indentation)
  46:1      error    trailing spaces  (trailing-spaces)
  50:89     error    line too long (99 > 88 characters)  (line-length)
  57:89     error    line too long (89 > 88 characters)  (line-length)
  70:1      error    trailing spaces  (trailing-spaces)
  71:89     error    line too long (96 > 88 characters)  (line-length)
  72:89     error    line too long (119 > 88 characters)  (line-length)
  73:51     warning  comment not indented like content  (comments-indentation)
  74:1      error    trailing spaces  (trailing-spaces)
  78:89     error    line too long (99 > 88 characters)  (line-length)
  85:89     error    line too long (89 > 88 characters)  (line-length)
  87:89     error    line too long (110 > 88 characters)  (line-length)
```
