### PR TITLE
fix(pillar.example): fix `octal-values` violation

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -7,9 +7,11 @@ extends: default
 # Files to ignore completely
 # 1. All YAML files under directory `node_modules/`, introduced during the Travis run
 # 2. Any SLS files under directory `test/`, which are actually state files
+# 3. Any YAML files under directory `.kitchen/`, introduced during local testing
 ignore: |
   node_modules/
   test/**/states/**/*.sls
+  .kitchen/
 
 yaml-files:
   # Default settings
@@ -38,3 +40,6 @@ rules:
     # Increase from default of `80`
     # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
     max: 88
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/pillar.example
+++ b/pillar.example
@@ -23,7 +23,7 @@ bind:
   lookup:
     key_directory: '/etc/bind/keys'               # Key directory (needed to use auto-dnssec)
     key_algorithm: RSASHA256                      # Algorithm when using auto-dnssec
-    key_algorithm_field: 008                      # See http://www.bind9.net/dns-sec-algorithm-numbers
+    key_algorithm_field: '008'                    # See http://www.bind9.net/dns-sec-algorithm-numbers
     key_size: 4096                                # Key size
 
   config:


### PR DESCRIPTION
* https://travis-ci.org/myii/bind-formula/builds/594704904#L211-L213

```bash
$ yamllint -s .
./pillar.example
  26:29     error    forbidden implicit octal value "008"  (octal-values)
```